### PR TITLE
Install git for server build image

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:10-alpine AS build
 
+# Install git
+RUN apk add --no-cache git
+
 # Create app directory
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
**This PR:**

* The last PR broke the server build because some new dependencies required `git` in order to be installed.