### PR TITLE
Add support for Celo Network APIs

### DIFF
--- a/packages/client/src/components/Balances.tsx
+++ b/packages/client/src/components/Balances.tsx
@@ -71,11 +71,10 @@ class Balance extends React.Component<IProps, {}> {
 
           const fiatConversionRate = prices.prices;
           const data = accountBalances.accountBalances;
-          const { denom } = this.props.ledger.network;
           const balances = getAccountBalances(
             data,
             fiatConversionRate,
-            denom,
+            network,
             2,
           );
 

--- a/packages/client/src/components/CreateTransactionForm.tsx
+++ b/packages/client/src/components/CreateTransactionForm.tsx
@@ -54,7 +54,7 @@ import {
 } from "tools/cosmos-utils";
 import {
   calculateTransactionAmount,
-  denomToAtoms,
+  denomToUnit,
   formatCurrencyAmount,
 } from "tools/currency-utils";
 import { bold } from "tools/i18n-utils";
@@ -257,7 +257,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
                     <b>{validator.description.moniker}</b>
                     <p style={{ margin: 0, marginLeft: 4 }}>
                       {formatCurrencyAmount(
-                        denomToAtoms(result.amount, String),
+                        denomToUnit(result.amount, String),
                         4,
                       )}{" "}
                       {ledger.network.descriptor}

--- a/packages/client/src/components/CreateTransactionForm.tsx
+++ b/packages/client/src/components/CreateTransactionForm.tsx
@@ -181,7 +181,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
           const balances = getAccountBalances(
             accountBalancesData,
             atomsConversionRate,
-            ledger.network.denom,
+            ledger.network,
             6,
           );
           const { rewards, rewardsFiat } = balances;
@@ -257,7 +257,11 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
                     <b>{validator.description.moniker}</b>
                     <p style={{ margin: 0, marginLeft: 4 }}>
                       {formatCurrencyAmount(
-                        denomToUnit(result.amount, String),
+                        denomToUnit(
+                          result.amount,
+                          network.denominationSize,
+                          String,
+                        ),
                         4,
                       )}{" "}
                       {ledger.network.descriptor}
@@ -333,7 +337,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
     const balances = getAccountBalances(
       accountBalances.accountBalances,
       atomsConversionRate,
-      ledger.network.denom,
+      ledger.network,
       6,
     );
     const { balance, balanceFiat } = balances;
@@ -703,7 +707,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
     const balances = getAccountBalances(
       accountBalances.accountBalances,
       atomsConversionRate,
-      ledger.network.denom,
+      ledger.network,
       6,
     );
 
@@ -713,6 +717,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
       targetValue,
       this.state.gasPrice,
       this.state.gasAmount,
+      ledger.network,
     );
 
     return maximumAmountAfterFees;
@@ -739,6 +744,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
   };
 
   updateValues = () => {
+    const { network } = this.props.ledger;
     const { amount, gasPrice, gasAmount, useFullBalance } = this.state;
     const doNotUpdate = gasPrice === "" || gasAmount === "";
 
@@ -748,6 +754,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
         useFullBalance ? maximumAmount : amount,
         gasPrice,
         gasAmount,
+        network,
       );
 
       this.setState(
@@ -833,7 +840,7 @@ class CreateTransactionForm extends React.Component<IProps, IState> {
         address,
         gasAmount,
         gasPrice,
-        network: network.name,
+        network,
         validatorOperatorAddress:
           selectedValidatorForDelegation.operator_address,
       });

--- a/packages/client/src/components/Portfolio.tsx
+++ b/packages/client/src/components/Portfolio.tsx
@@ -296,7 +296,7 @@ class Portfolio extends React.PureComponent<IProps, IState> {
   };
 
   calculatePortfolioData = () => {
-    const { settings, portfolioHistory } = this.props;
+    const { settings, network, portfolioHistory } = this.props;
 
     if (portfolioHistory && portfolioHistory.portfolioHistory) {
       const { validatorCommissions } = portfolioHistory.portfolioHistory;
@@ -321,6 +321,7 @@ class Portfolio extends React.PureComponent<IProps, IState> {
       const result = processPortfolioHistoryData(
         this.props.portfolioHistory,
         displayFiat,
+        network,
       );
 
       this.setState({ portfolioChartData: result });
@@ -359,6 +360,7 @@ class Portfolio extends React.PureComponent<IProps, IState> {
       const portfolioData = processPortfolioHistoryData(
         portfolioHistory,
         false,
+        network,
       );
 
       if (

--- a/packages/client/src/graphql/queries.ts
+++ b/packages/client/src/graphql/queries.ts
@@ -1,6 +1,8 @@
 import {
   AccountBalancesDocument,
   AccountInformationDocument,
+  CeloAccountHistoryDocument,
+  CeloTransactionsDocument,
   CosmosTransactionsDocument,
   DailyPercentChangeDocument,
   FiatCurrenciesDocument,
@@ -20,7 +22,10 @@ import { connect } from "react-redux";
 import { createSelector } from "reselect";
 
 /** ===========================================================================
- * GraphQL Data:
+ * Query Providers
+ * ----------------------------------------------------------------------------
+ * These are helpers to make it easy to fetch data from GraphQL APIs and
+ * provide the response data components.
  * ============================================================================
  */
 
@@ -54,11 +59,6 @@ const mapGraphQLVariablesToProps = (state: ReduxStoreState) => ({
 export type GraphQLConfigProps = ReturnType<typeof mapGraphQLVariablesToProps>;
 
 export const withGraphQLVariables = connect(mapGraphQLVariablesToProps);
-
-/** ===========================================================================
- * Types & Config
- * ============================================================================
- */
 
 const getQueryConfig = (pollInterval: number | undefined) => (
   variableKeys?: ReadonlyArray<VariablesKeys>,
@@ -104,15 +104,8 @@ const noPollingConfig = (variableKeys?: ReadonlyArray<VariablesKeys>) => {
 };
 
 /** ===========================================================================
- * Query Providers
- * ----------------------------------------------------------------------------
- * These are helpers to make it easy to fetch data from GraphQL APIs and
- * provide the response data components.
- * ============================================================================
- */
-
-/**
  * AccountBalance
+ * ============================================================================
  */
 
 interface AccountBalancesQueryResult extends QueryResult {
@@ -129,8 +122,9 @@ export const withAccountBalances = graphql(AccountBalancesDocument, {
   ...fastPollingConfig(["address"]),
 });
 
-/**
+/** ===========================================================================
  * AtomPriceData
+ * ============================================================================
  */
 
 interface AtomPriceDataQueryResult extends QueryResult {
@@ -147,8 +141,9 @@ export const withAtomPriceData = graphql(PricesDocument, {
   ...fastPollingConfig(["versus", "currency"]),
 });
 
-/**
+/** ===========================================================================
  * DailyPercentageChange
+ * ============================================================================
  */
 
 interface DailyPercentChangeQueryResult extends QueryResult {
@@ -165,8 +160,9 @@ export const withDailyPercentChange = graphql(DailyPercentChangeDocument, {
   ...fastPollingConfig(["crypto", "fiat"]),
 });
 
-/**
+/** ===========================================================================
  * RewardsByValidator
+ * ============================================================================
  */
 
 interface RewardsByValidatorQueryResult extends QueryResult {
@@ -183,8 +179,9 @@ export const withRewardsByValidatorQuery = graphql(RewardsByValidatorDocument, {
   ...slowPollingConfig(["address"]),
 });
 
-/**
+/** ===========================================================================
  * Portfolio History
+ * ============================================================================
  */
 
 export interface PortfolioHistoryQueryResult extends QueryResult {
@@ -201,8 +198,9 @@ export const withPortfolioHistoryDataQuery = graphql(PortfolioHistoryDocument, {
   ...slowPollingConfig(["address", "fiat"]),
 });
 
-/**
+/** ===========================================================================
  * FiatPriceHistory
+ * ============================================================================
  */
 
 interface FiatPriceHistoryQueryResult extends QueryResult {
@@ -219,8 +217,9 @@ export const withFiatPriceHistory = graphql(FiatPriceHistoryDocument, {
   ...noPollingConfig(["fiat", "network"]),
 });
 
-/**
+/** ===========================================================================
  * FiatCurrencies
+ * ============================================================================
  */
 
 interface FiatCurrenciesQueryResult extends QueryResult {
@@ -237,8 +236,9 @@ export const withFiatCurrencies = graphql(FiatCurrenciesDocument, {
   ...noPollingConfig(),
 });
 
-/**
+/** ===========================================================================
  * AccountInformation
+ * ============================================================================
  */
 
 interface AccountInformationQueryResult extends QueryResult {
@@ -255,8 +255,9 @@ export const withAccountInformation = graphql(AccountInformationDocument, {
   ...slowPollingConfig(["address"]),
 });
 
-/**
+/** ===========================================================================
  * Cosmos Transactions
+ * ============================================================================
  */
 
 interface CosmosTransactionsQueryResult extends QueryResult {
@@ -273,26 +274,9 @@ export const withCosmosTransactions = graphql(CosmosTransactionsDocument, {
   ...noPollingConfig(["address", "startingPage"]),
 });
 
-/**
- * Oasis Transactions
- */
-
-interface OasisTransactionsQueryResult extends QueryResult {
-  data: void;
-  oasisTransactions: IQuery["oasisTransactions"];
-}
-
-export interface OasisTransactionsProps {
-  transactions: OasisTransactionsQueryResult;
-}
-
-export const withOasisTransactions = graphql(OasisTransactionsDocument, {
-  name: "transactions",
-  ...noPollingConfig(["address", "startingPage"]),
-});
-
-/**
+/** ===========================================================================
  * Validators
+ * ============================================================================
  */
 
 interface ValidatorsQueryResult extends QueryResult {
@@ -309,8 +293,9 @@ export const withValidators = graphql(ValidatorsDocument, {
   ...noPollingConfig(["network"]),
 });
 
-/**
+/** ===========================================================================
  * Staking Pool
+ * ============================================================================
  */
 
 interface StakingPoolQueryResult extends QueryResult {
@@ -325,4 +310,61 @@ export interface StakingPoolProps {
 export const withStakingPool = graphql(StakingPoolDocument, {
   name: "stakingPool",
   ...noPollingConfig(["network"]),
+});
+
+/** ===========================================================================
+ * Oasis Transactions
+ * ============================================================================
+ */
+
+interface OasisTransactionsQueryResult extends QueryResult {
+  data: void;
+  oasisTransactions: IQuery["oasisTransactions"];
+}
+
+export interface OasisTransactionsProps {
+  transactions: OasisTransactionsQueryResult;
+}
+
+export const withOasisTransactions = graphql(OasisTransactionsDocument, {
+  name: "transactions",
+  ...noPollingConfig(["address", "startingPage"]),
+});
+
+/** ===========================================================================
+ * Celo Account History
+ * ============================================================================
+ */
+
+interface CeloAccountHistoryQueryResult extends QueryResult {
+  data: void;
+  celoAccountHistory: IQuery["celoAccountHistory"];
+}
+
+export interface CeoTransactionsProps {
+  celoAccountHistory: CeloAccountHistoryQueryResult;
+}
+
+export const withCeloAccountHistory = graphql(CeloAccountHistoryDocument, {
+  name: "celoAccountHistory",
+  ...noPollingConfig(["address", "fiat"]),
+});
+
+/** ===========================================================================
+ * Celo Transactions
+ * ============================================================================
+ */
+
+interface CeloTransactionsQueryResult extends QueryResult {
+  data: void;
+  celoTransactions: IQuery["celoTransactions"];
+}
+
+export interface CeoTransactionsProps {
+  transactions: CeloTransactionsQueryResult;
+}
+
+export const withCeloTransactions = graphql(CeloTransactionsDocument, {
+  name: "transactions",
+  ...noPollingConfig(["address", "startingPage"]),
 });

--- a/packages/client/src/test/chart-and-csv-utils.test.ts
+++ b/packages/client/src/test/chart-and-csv-utils.test.ts
@@ -9,6 +9,7 @@ describe("chart-and-csv-utils", () => {
     const portfolioChartHistory: any = processPortfolioHistoryData(
       portfolioHistory as any,
       false,
+      NETWORKS.COSMOS,
     );
 
     const result = chartExportBuilder({

--- a/packages/client/src/test/client-utils.test.ts
+++ b/packages/client/src/test/client-utils.test.ts
@@ -205,7 +205,7 @@ describe("utils", () => {
     const result = getAccountBalances(
       accountBalances.accountBalances,
       prices.prices,
-      "uatom",
+      NETWORKS.COSMOS,
     );
     expect(result).toMatchInlineSnapshot(`
       Object {

--- a/packages/client/src/test/cosmos-utils.test.ts
+++ b/packages/client/src/test/cosmos-utils.test.ts
@@ -17,7 +17,7 @@ describe("cosmos-utils", () => {
       gasAmount: "1500",
       gasPrice: "150000",
       denom: "uatom",
-      network: "COSMOS",
+      network: NETWORKS.COSMOS,
       validatorOperatorAddress:
         "cosmosvaloper15urq2dtp9qce4fyc85m6upwm9xul3049e02707",
     });

--- a/packages/client/src/test/currency-utils.test.ts
+++ b/packages/client/src/test/currency-utils.test.ts
@@ -1,11 +1,11 @@
 import BigNumber from "bignumber.js";
 import {
-  atomsToDenom,
   calculateTransactionAmount,
   convertCryptoToFiat,
-  denomToAtoms,
+  denomToUnit,
   findCurrencyFromCoinsList,
   formatCurrencyAmount,
+  unitToDenom,
 } from "tools/currency-utils";
 import { coins } from "../../../utils/src/client/data/coins.json";
 import prices from "../../../utils/src/client/data/prices.json";
@@ -46,13 +46,13 @@ describe("currency-utils", () => {
   });
 
   test("denomToAtoms", () => {
-    let result = denomToAtoms(5000, String);
+    let result = denomToUnit(5000, String);
     expect(result).toMatchInlineSnapshot(`"0.005"`);
 
-    result = denomToAtoms(0, String);
+    result = denomToUnit(0, String);
     expect(result).toMatchInlineSnapshot(`"0"`);
 
-    result = denomToAtoms(5.9082649012634, String);
+    result = denomToUnit(5.9082649012634, String);
     expect(result).toMatchInlineSnapshot(`"0.0000059082649012634"`);
   });
 
@@ -71,7 +71,7 @@ describe("currency-utils", () => {
   });
 
   test("atomsToDenom", () => {
-    const result = atomsToDenom("500");
+    const result = unitToDenom("500");
     expect(result).toMatchInlineSnapshot(`"500000000"`);
   });
 

--- a/packages/client/src/test/currency-utils.test.ts
+++ b/packages/client/src/test/currency-utils.test.ts
@@ -1,3 +1,4 @@
+import { NETWORKS } from "@anthem/utils";
 import BigNumber from "bignumber.js";
 import {
   calculateTransactionAmount,
@@ -46,37 +47,58 @@ describe("currency-utils", () => {
   });
 
   test("denomToAtoms", () => {
-    let result = denomToUnit(5000, String);
+    let result = denomToUnit(5000, 1e6, String);
     expect(result).toMatchInlineSnapshot(`"0.005"`);
 
-    result = denomToUnit(0, String);
+    result = denomToUnit(0, 1e6, String);
     expect(result).toMatchInlineSnapshot(`"0"`);
 
-    result = denomToUnit(5.9082649012634, String);
+    result = denomToUnit(5.9082649012634, 1e6, String);
     expect(result).toMatchInlineSnapshot(`"0.0000059082649012634"`);
   });
 
   test("convertAtomsToUsd", () => {
-    let result = convertCryptoToFiat(prices.prices, new BigNumber(5000));
+    let result = convertCryptoToFiat(
+      prices.prices,
+      new BigNumber(5000),
+      NETWORKS.COSMOS,
+    );
     expect(result).toMatchInlineSnapshot(`"0.0137"`);
 
-    result = convertCryptoToFiat(prices.prices, new BigNumber(15));
+    result = convertCryptoToFiat(
+      prices.prices,
+      new BigNumber(15),
+      NETWORKS.COSMOS,
+    );
     expect(result).toMatchInlineSnapshot(`"0.0000411"`);
 
-    result = convertCryptoToFiat(prices.prices, new BigNumber(1000000));
+    result = convertCryptoToFiat(
+      prices.prices,
+      new BigNumber(1000000),
+      NETWORKS.COSMOS,
+    );
     expect(result).toMatchInlineSnapshot(`"2.74"`);
 
-    result = convertCryptoToFiat(prices.prices, new BigNumber(100000000));
+    result = convertCryptoToFiat(
+      prices.prices,
+      new BigNumber(100000000),
+      NETWORKS.COSMOS,
+    );
     expect(result).toMatchInlineSnapshot(`"274"`);
   });
 
   test("atomsToDenom", () => {
-    const result = unitToDenom("500");
+    const result = unitToDenom("500", 1e6);
     expect(result).toMatchInlineSnapshot(`"500000000"`);
   });
 
   test("calculateTransactionAmount", () => {
-    const result = calculateTransactionAmount("500000", "1500", "150000");
+    const result = calculateTransactionAmount(
+      "500000",
+      "1500",
+      "150000",
+      NETWORKS.COSMOS,
+    );
     expect(result).toMatchInlineSnapshot(`"499775"`);
   });
 });

--- a/packages/client/src/tools/chart-utils.ts
+++ b/packages/client/src/tools/chart-utils.ts
@@ -2,7 +2,7 @@ import { PortfolioChartData } from "components/Portfolio";
 import { PortfolioHistoryQueryResult } from "graphql/queries";
 import { PORTFOLIO_CHART_TYPES } from "i18n/english";
 import moment from "moment-timezone";
-import { denomToAtoms } from "./currency-utils";
+import { denomToUnit } from "./currency-utils";
 import { toDateKey, toDateKeyBackOneDay } from "./date-utils";
 import {
   add,
@@ -177,7 +177,7 @@ export const mapBalancesToChartData = (
   const data: ChartSeries = {};
 
   balanceHistory.forEach(({ balance, timestamp, fiatPrice }) => {
-    const x = denomToAtoms(balance, Number);
+    const x = denomToUnit(balance, Number);
     const value = displayFiat ? Number(fiatPrice) * x : x;
     const reward = Number(value);
     const time = toDateKey(timestamp);
@@ -209,13 +209,13 @@ export const mapDelegationsToChartData = (
   let rewardsByTime: Set<string> = new Set();
 
   for (const { balance, timestamp, fiatPrice } of delegationsData) {
-    const x = denomToAtoms(balance, Number);
+    const x = denomToUnit(balance, Number);
     const value = displayFiat ? multiply(fiatPrice, x, Number) : x;
     const time = toDateKey(timestamp);
     data[time] = value;
 
     if (isLessThan(balance, lastRewards)) {
-      const diff = denomToAtoms(subtract(lastRewards, balance));
+      const diff = denomToUnit(subtract(lastRewards, balance));
       const displayDiff = displayFiat ? multiply(fiatPrice, diff) : diff;
       withdrawalsMap[time] = displayDiff;
     }
@@ -271,7 +271,7 @@ export const mapRewardsToChartData = (
 
     if (isLessThan(value, lastRewards)) {
       const denoms = subtract(lastRewards, value);
-      const atoms = denomToAtoms(denoms);
+      const atoms = denomToUnit(denoms);
 
       const displayValue = displayFiat ? multiply(fiatPrice, atoms) : atoms;
 
@@ -294,7 +294,7 @@ export const mapRewardsToChartData = (
 
   // Create a map of all earned rewards by date.
   for (const { balance, timestamp, fiatPrice } of rewardsData) {
-    const atomReward = denomToAtoms(balance, Number);
+    const atomReward = denomToUnit(balance, Number);
 
     /**
      * Determine the timestamp string based on the duration of the
@@ -348,7 +348,7 @@ export const mapRewardsToDailySummary = (
   const data: ChartSeries = {};
 
   rewardsHistory.forEach(({ balance, timestamp, fiatPrice }) => {
-    const x = denomToAtoms(balance, Number);
+    const x = denomToUnit(balance, Number);
     const value = displayFiat ? Number(fiatPrice) * x : x;
     const reward = Number(value);
     const time = toDateKeyBackOneDay(timestamp);

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -20,7 +20,7 @@ import { PORTFOLIO_CHART_TYPES } from "i18n/english";
 import queryString, { ParsedQuery } from "query-string";
 import {
   convertCryptoToFiat,
-  denomToAtoms,
+  denomToUnit,
   formatCurrencyAmount,
 } from "./currency-utils";
 import { formatFiatPriceDate } from "./date-utils";
@@ -313,12 +313,12 @@ export const getAccountBalances = (
     commissionsFiat,
     totalFiat,
   ]: ReadonlyArray<string> = [
-    denomToAtoms(balanceResult, String),
-    denomToAtoms(rewardsResult, String),
-    denomToAtoms(delegationResult, String),
-    denomToAtoms(unbondingResult, String),
-    denomToAtoms(commissionsResult, String),
-    denomToAtoms(totalResult, String),
+    denomToUnit(balanceResult, String),
+    denomToUnit(rewardsResult, String),
+    denomToUnit(delegationResult, String),
+    denomToUnit(unbondingResult, String),
+    denomToUnit(commissionsResult, String),
+    denomToUnit(totalResult, String),
     // The rate is undefined for non fiat supported networks
     rate ? convertCryptoToFiat(rate, balanceResult) : "0",
     rate ? convertCryptoToFiat(rate, delegationResult) : "0",

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -211,9 +211,10 @@ interface AccountBalancesResult {
 export const getAccountBalances = (
   accountBalancesData: IQuery["accountBalances"] | undefined,
   rate: IQuery["prices"] | undefined,
-  denom: COIN_DENOMS,
+  network: NetworkDefinition,
   maximumFractionDigits?: number,
 ): AccountBalancesResult => {
+  const { denom, denominationSize } = network;
   const defaultResult = {
     balance: "",
     rewards: "",
@@ -313,19 +314,19 @@ export const getAccountBalances = (
     commissionsFiat,
     totalFiat,
   ]: ReadonlyArray<string> = [
-    denomToUnit(balanceResult, String),
-    denomToUnit(rewardsResult, String),
-    denomToUnit(delegationResult, String),
-    denomToUnit(unbondingResult, String),
-    denomToUnit(commissionsResult, String),
-    denomToUnit(totalResult, String),
+    denomToUnit(balanceResult, denominationSize, String),
+    denomToUnit(rewardsResult, denominationSize, String),
+    denomToUnit(delegationResult, denominationSize, String),
+    denomToUnit(unbondingResult, denominationSize, String),
+    denomToUnit(commissionsResult, denominationSize, String),
+    denomToUnit(totalResult, denominationSize, String),
     // The rate is undefined for non fiat supported networks
-    rate ? convertCryptoToFiat(rate, balanceResult) : "0",
-    rate ? convertCryptoToFiat(rate, delegationResult) : "0",
-    rate ? convertCryptoToFiat(rate, rewardsResult) : "0",
-    rate ? convertCryptoToFiat(rate, unbondingResult) : "0",
-    rate ? convertCryptoToFiat(rate, commissionsResult) : "0",
-    rate ? convertCryptoToFiat(rate, totalResult) : "0",
+    rate ? convertCryptoToFiat(rate, balanceResult, network) : "0",
+    rate ? convertCryptoToFiat(rate, delegationResult, network) : "0",
+    rate ? convertCryptoToFiat(rate, rewardsResult, network) : "0",
+    rate ? convertCryptoToFiat(rate, unbondingResult, network) : "0",
+    rate ? convertCryptoToFiat(rate, commissionsResult, network) : "0",
+    rate ? convertCryptoToFiat(rate, totalResult, network) : "0",
   ].map(x => formatCurrencyAmount(x, maximumFractionDigits));
 
   const getPercentage = (value: BigNumber) => {

--- a/packages/client/src/tools/cosmos-utils.ts
+++ b/packages/client/src/tools/cosmos-utils.ts
@@ -11,7 +11,7 @@ import {
 } from "@anthem/utils";
 import { AvailableReward } from "components/CreateTransactionForm";
 import { LEDGER_ACTION_TYPE } from "modules/ledger/actions";
-import { atomsToDenom } from "./currency-utils";
+import { unitToDenom } from "./currency-utils";
 import { multiply } from "./math-utils";
 
 /** ===========================================================================
@@ -152,7 +152,7 @@ export const createDelegationTransactionMessage = (args: {
           validator_address: validatorOperatorAddress,
           amount: {
             denom,
-            amount: atomsToDenom(amount, String),
+            amount: unitToDenom(amount, String),
           },
         },
       },

--- a/packages/client/src/tools/cosmos-utils.ts
+++ b/packages/client/src/tools/cosmos-utils.ts
@@ -117,7 +117,7 @@ export const createDelegationTransactionMessage = (args: {
   gasAmount: string;
   gasPrice: string;
   denom: COIN_DENOMS;
-  network: NETWORK_NAME;
+  network: NetworkDefinition;
   validatorOperatorAddress: string;
 }): ITxValue => {
   const {
@@ -130,7 +130,7 @@ export const createDelegationTransactionMessage = (args: {
     validatorOperatorAddress,
   } = args;
 
-  const type = getTransactionMessageTypeForNetwork(network, "DELEGATE");
+  const type = getTransactionMessageTypeForNetwork(network.name, "DELEGATE");
 
   return {
     fee: {
@@ -152,7 +152,7 @@ export const createDelegationTransactionMessage = (args: {
           validator_address: validatorOperatorAddress,
           amount: {
             denom,
-            amount: unitToDenom(amount, String),
+            amount: unitToDenom(amount, network.denominationSize, String),
           },
         },
       },

--- a/packages/client/src/tools/currency-utils.ts
+++ b/packages/client/src/tools/currency-utils.ts
@@ -86,8 +86,8 @@ interface CurrencyConversionMethodTypes {
 /**
  * Convert an ATOM denomination to the normal ATOM amount.
  */
-export const denomToAtoms: CurrencyConversionMethodTypes = (
-  denoms: any,
+export const denomToUnit: CurrencyConversionMethodTypes = (
+  denoms: GenericNumberType,
   targetConstructorFn: any = String,
 ) => {
   const amount = valueToBigNumber(denoms);
@@ -98,8 +98,8 @@ export const denomToAtoms: CurrencyConversionMethodTypes = (
 /**
  * Convert an ATOM amount back to the raw ATOM denomination.
  */
-export const atomsToDenom: CurrencyConversionMethodTypes = (
-  amount: any,
+export const unitToDenom: CurrencyConversionMethodTypes = (
+  amount: GenericNumberType,
   targetConstructorFn: any = String,
 ) => {
   const value = valueToBigNumber(amount);
@@ -118,7 +118,7 @@ export const convertCryptoToFiat = (
   if (priceQuery) {
     const { price } = priceQuery;
     if (price) {
-      const atoms = denomToAtoms(amount);
+      const atoms = denomToUnit(amount);
       const fiat = multiply(atoms, price);
       return fiat;
     }
@@ -142,9 +142,9 @@ export const calculateTransactionAmount = (
   ].map(valueToBigNumber);
 
   const fee = multiply(gasPrice, gasAmount);
-  const denoms = atomsToDenom(available, toBigNumber);
+  const denoms = unitToDenom(available, toBigNumber);
   const availableAmountDenom = subtract(denoms, fee);
-  const availableAmount = denomToAtoms(availableAmountDenom);
+  const availableAmount = denomToUnit(availableAmountDenom);
 
   return availableAmount;
 };

--- a/packages/client/src/tools/currency-utils.ts
+++ b/packages/client/src/tools/currency-utils.ts
@@ -110,10 +110,11 @@ export const denomToUnit: CurrencyConversionMethodTypes = (
  */
 export const unitToDenom: CurrencyConversionMethodTypes = (
   amount: GenericNumberType,
+  networkDenominationSize: GenericNumberType,
   targetConstructorFn: any = String,
 ) => {
   const value = valueToBigNumber(amount);
-  const result = multiply(value, 1e6);
+  const result = multiply(value, networkDenominationSize);
   return targetConstructorFn(result);
 };
 

--- a/packages/client/src/transactions/CosmosTransactionList.tsx
+++ b/packages/client/src/transactions/CosmosTransactionList.tsx
@@ -164,6 +164,7 @@ class CosmosTransactionList extends React.PureComponent<IProps> {
   };
 
   getFiatPriceForTransaction = (timestamp: string, amount: string): string => {
+    const { network } = this.props.ledger;
     const transactionPrice = getPriceFromTransactionTimestamp(
       timestamp,
       this.priceHistoryMap,
@@ -173,7 +174,8 @@ class CosmosTransactionList extends React.PureComponent<IProps> {
       {
         price: Number(transactionPrice),
       },
-      unitToDenom(amount),
+      unitToDenom(amount, network.denominationSize),
+      network,
     );
 
     return fiatPrice;

--- a/packages/client/src/transactions/CosmosTransactionList.tsx
+++ b/packages/client/src/transactions/CosmosTransactionList.tsx
@@ -12,7 +12,7 @@ import {
   PriceHistoryMap,
   ValidatorOperatorAddressMap,
 } from "tools/client-utils";
-import { atomsToDenom, convertCryptoToFiat } from "tools/currency-utils";
+import { convertCryptoToFiat, unitToDenom } from "tools/currency-utils";
 import { TransactionListProps } from "./CosmosTransactionContainer";
 import TransactionListItem from "./CosmosTransactionListItem";
 import { TransactionPaginationControls } from "./TransactionComponents";
@@ -173,7 +173,7 @@ class CosmosTransactionList extends React.PureComponent<IProps> {
       {
         price: Number(transactionPrice),
       },
-      atomsToDenom(amount),
+      unitToDenom(amount),
     );
 
     return fiatPrice;

--- a/packages/client/src/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/transactions/CosmosTransactionListItem.tsx
@@ -38,7 +38,7 @@ import {
   ValidatorCreateOrEditMessageData,
   ValidatorModifyWithdrawAddressMessageData,
 } from "tools/cosmos-transaction-utils";
-import { denomToAtoms, formatCurrencyAmount } from "tools/currency-utils";
+import { denomToUnit, formatCurrencyAmount } from "tools/currency-utils";
 import { formatDate, formatTime } from "tools/date-utils";
 import { tFnString, TranslateMethodProps } from "tools/i18n-utils";
 import AddressIconComponent from "../components/AddressIconComponent";
@@ -305,7 +305,7 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventIconBox>
         <EventContextBox>
           <EventText style={{ fontWeight: "bold" }}>
-            {formatCurrencyAmount(denomToAtoms(amount))} ATOM
+            {formatCurrencyAmount(denomToUnit(amount))} ATOM
           </EventText>
           <EventText>
             {this.getFiatAmount(amount, timestamp)} {fiatCurrency.symbol}
@@ -370,7 +370,7 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   renderTransactionFeesRow = (fees: string, transaction: ITransaction) => {
     const { hash, height, timestamp, chain } = transaction;
     const { t, fiatCurrency } = this.props;
-    const atomFees = denomToAtoms(fees);
+    const atomFees = denomToUnit(fees);
     const fiatFees = this.props.getFiatPriceForTransaction(timestamp, atomFees);
 
     return (
@@ -399,7 +399,7 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
 
   getFiatAmount = (amount: string, timestamp: string) => {
     return formatCurrencyAmount(
-      this.props.getFiatPriceForTransaction(timestamp, denomToAtoms(amount)),
+      this.props.getFiatPriceForTransaction(timestamp, denomToUnit(amount)),
     );
   };
 

--- a/packages/client/src/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/transactions/CosmosTransactionListItem.tsx
@@ -289,8 +289,9 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   };
 
   renderTransactionAmount = (amount: Nullable<string>, timestamp: string) => {
+    const { network, isDesktop } = this.props;
     if (!amount) {
-      if (this.props.isDesktop) {
+      if (isDesktop) {
         return <EventRowItem style={{ minWidth: 275 }} />;
       } else {
         return null;
@@ -305,7 +306,10 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventIconBox>
         <EventContextBox>
           <EventText style={{ fontWeight: "bold" }}>
-            {formatCurrencyAmount(denomToUnit(amount))} ATOM
+            {formatCurrencyAmount(
+              denomToUnit(amount, network.denominationSize),
+            )}{" "}
+            ATOM
           </EventText>
           <EventText>
             {this.getFiatAmount(amount, timestamp)} {fiatCurrency.symbol}
@@ -369,8 +373,8 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
 
   renderTransactionFeesRow = (fees: string, transaction: ITransaction) => {
     const { hash, height, timestamp, chain } = transaction;
-    const { t, fiatCurrency } = this.props;
-    const atomFees = denomToUnit(fees);
+    const { t, network, fiatCurrency } = this.props;
+    const atomFees = denomToUnit(fees, network.denominationSize);
     const fiatFees = this.props.getFiatPriceForTransaction(timestamp, atomFees);
 
     return (
@@ -398,8 +402,12 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   };
 
   getFiatAmount = (amount: string, timestamp: string) => {
+    const { denominationSize } = this.props.network;
     return formatCurrencyAmount(
-      this.props.getFiatPriceForTransaction(timestamp, denomToUnit(amount)),
+      this.props.getFiatPriceForTransaction(
+        timestamp,
+        denomToUnit(amount, denominationSize),
+      ),
     );
   };
 

--- a/packages/server/src/schema/schema.graphql
+++ b/packages/server/src/schema/schema.graphql
@@ -38,10 +38,55 @@ type Query {
     startingPage: Float
     pageSize: Float
   ): OasisTransactionResult!
+
+  # Celo APIs
+  celoAccountHistory(address: String!, fiat: String!): [CeloAccountSnapshot!]!
+  celoTransactions(
+    address: String!
+    startingPage: Float
+    pageSize: Float
+  ): CeloTransactionResult!
 }
 
 # *****************************************************************************
-# Cosmos APIs
+# Celo APIs
+
+type CeloDelegation {
+  group: String!
+  totalVotes: String!
+  activeVotes: String!
+  pendingVotes: String!
+}
+
+type CeloAccountSnapshot {
+  snapshotDate: String!
+  address: String!
+  height: String!
+  snapshotReward: String!
+  goldTokenBalance: String!
+  totalLockedGoldBalance: String!
+  nonVotingLockedGoldBalance: String!
+  votingLockedGoldBalance: String!
+  pendingWithdrawalBalance: String!
+  celoUSDValue: String!
+  delegations: [CeloDelegation!]!
+}
+
+type CeloTransactionResult {
+  page: Float!
+  limit: Float!
+  data: [CeloTransaction!]!
+  moreResultsExist: Boolean!
+}
+
+# TODO: Complete the transaction/events types for Celo
+type CeloTransaction {
+  date: String!
+  height: Int!
+}
+
+# *****************************************************************************
+# Oasis APIs
 
 type OasisTransactionResult {
   page: Float!

--- a/packages/server/src/server/axios-utils.ts
+++ b/packages/server/src/server/axios-utils.ts
@@ -15,7 +15,7 @@ const COSMOS_API = "https://stargate.cosmos.network";
 const COIN_GECKO_API = "https://api.coingecko.com/api/v3";
 const CRYPTO_COMPARE = "https://min-api.cryptocompare.com";
 const OASIS = "http://216.18.206.50:10100";
-const CELO = "???";
+const CELO = "http://158.85.63.136";
 
 const HOSTS = {
   COSMOS_LCD,

--- a/packages/server/src/server/resolvers.ts
+++ b/packages/server/src/server/resolvers.ts
@@ -171,6 +171,8 @@ const resolvers = {
 
       if (network.name === "OASIS") {
         return OASIS.fetchAccountBalances(address, network);
+      } else if (network.name === "CELO") {
+        return CELO.fetchAccountBalances(address, network);
       } else {
         const [
           balance,

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -1,11 +1,4 @@
-import {
-  IDelegation,
-  IOasisTransaction,
-  IOasisTransactionType,
-  IQuery,
-  NetworkDefinition,
-} from "@anthem/utils";
-import { logSentryMessage } from "../../tools/server-utils";
+import { IDelegation, IQuery, NetworkDefinition } from "@anthem/utils";
 import { AxiosUtil, getHostFromNetworkName } from "../axios-utils";
 
 /** ===========================================================================

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -1,0 +1,166 @@
+import {
+  IDelegation,
+  IOasisTransaction,
+  IOasisTransactionType,
+  IQuery,
+  NetworkDefinition,
+} from "@anthem/utils";
+import { logSentryMessage } from "../../tools/server-utils";
+import { AxiosUtil, getHostFromNetworkName } from "../axios-utils";
+
+/** ===========================================================================
+ * Types & Config
+ * ============================================================================
+ */
+
+interface CeloDelegation {
+  group: string;
+  totalVotes: string;
+  activeVotes: string;
+  pendingVotes: string;
+}
+
+interface CeloAccountResponse {
+  address: string;
+  height: string;
+  goldTokenBalance: string;
+  totalLockedGoldBalance: string;
+  nonVotingLockedGoldBalance: string;
+  votingLockedGoldBalance: string;
+  pendingWithdrawalBalance: string;
+  celoUSDValue: string;
+  delegations: CeloDelegation[];
+}
+
+interface CeloAccountSnapshot {
+  snapshotDate: string;
+  address: string;
+  height: string;
+  snapshotReward: string;
+  goldTokenBalance: string;
+  totalLockedGoldBalance: string;
+  nonVotingLockedGoldBalance: string;
+  votingLockedGoldBalance: string;
+  pendingWithdrawalBalance: string;
+  celoUSDValue: string;
+  delegations: CeloDelegation[];
+}
+
+/** ===========================================================================
+ * Celo REST API Utils
+ * ----------------------------------------------------------------------------
+ * This file contains the utils for fetching Celo Network data.
+ * ============================================================================
+ */
+
+/**
+ * Fetch Celo account balances.
+ */
+const fetchAccountBalances = async (
+  address: string,
+  network: NetworkDefinition,
+): Promise<IQuery["accountBalances"]> => {
+  const host = getHostFromNetworkName(network.name);
+  const response = await AxiosUtil.get<CeloAccountResponse>(
+    `${host}/account/${address}`,
+  );
+
+  const {
+    delegations,
+    goldTokenBalance,
+    totalLockedGoldBalance,
+    nonVotingLockedGoldBalance,
+    votingLockedGoldBalance,
+    pendingWithdrawalBalance,
+  } = response;
+
+  return {
+    balance: [
+      {
+        denom: network.denom,
+        amount: goldTokenBalance,
+      },
+    ],
+    rewards: [
+      {
+        denom: network.denom,
+        amount: pendingWithdrawalBalance,
+      },
+    ],
+    delegations: delegations.map(x => convertDelegations(x, address)),
+    unbonding: [],
+    commissions: [],
+  };
+};
+
+/**
+ * Fetch account history.
+ */
+const fetchAccountHistory = async (
+  address: string,
+  network: NetworkDefinition,
+): Promise<IQuery["celoAccountHistory"]> => {
+  const host = getHostFromNetworkName(network.name);
+  const response = await AxiosUtil.get<CeloAccountSnapshot[]>(
+    `${host}/history/${address}`,
+  );
+
+  return response;
+};
+
+/**
+ * Fetch transactions history.
+ */
+const fetchTransactions = async (
+  address: string,
+  pageSize: number,
+  startingPage: number,
+  network: NetworkDefinition,
+): Promise<IQuery["celoTransactions"]> => {
+  const host = getHostFromNetworkName(network.name);
+
+  // TODO: Implement
+  // const response = await AxiosUtil.get<any[]>(
+  //   `${host}/account/${address}/events`,
+  // );
+
+  return {
+    page: 1,
+    limit: 25,
+    moreResultsExist: false,
+    data: [],
+  };
+};
+
+/** ===========================================================================
+ * Utils
+ * ============================================================================
+ */
+
+/**
+ * Transform the delegations to match the expected GraphQL schema
+ * definition.
+ */
+const convertDelegations = (
+  delegation: CeloDelegation,
+  address: string,
+): IDelegation => {
+  return {
+    delegator_address: address,
+    validator_address: delegation.group,
+    shares: delegation.totalVotes,
+  };
+};
+
+/** ===========================================================================
+ * Export
+ * ============================================================================
+ */
+
+const CELO = {
+  fetchAccountBalances,
+  fetchAccountHistory,
+  fetchTransactions,
+};
+
+export default CELO;

--- a/packages/utils/src/graphql/types.tsx
+++ b/packages/utils/src/graphql/types.tsx
@@ -85,6 +85,44 @@ export interface IBlockHeader {
   proposer_address: Scalars["String"];
 }
 
+export interface ICeloAccountSnapshot {
+   __typename?: "CeloAccountSnapshot";
+  snapshotDate: Scalars["String"];
+  address: Scalars["String"];
+  height: Scalars["String"];
+  snapshotReward: Scalars["String"];
+  goldTokenBalance: Scalars["String"];
+  totalLockedGoldBalance: Scalars["String"];
+  nonVotingLockedGoldBalance: Scalars["String"];
+  votingLockedGoldBalance: Scalars["String"];
+  pendingWithdrawalBalance: Scalars["String"];
+  celoUSDValue: Scalars["String"];
+  delegations: ICeloDelegation[];
+}
+
+export interface ICeloDelegation {
+   __typename?: "CeloDelegation";
+  group: Scalars["String"];
+  totalVotes: Scalars["String"];
+  activeVotes: Scalars["String"];
+  pendingVotes: Scalars["String"];
+}
+
+/** TODO: Complete the transaction/events types for Celo */
+export interface ICeloTransaction {
+   __typename?: "CeloTransaction";
+  date: Scalars["String"];
+  height: Scalars["Int"];
+}
+
+export interface ICeloTransactionResult {
+   __typename?: "CeloTransactionResult";
+  page: Scalars["Float"];
+  limit: Scalars["Float"];
+  data: ICeloTransaction[];
+  moreResultsExist: Scalars["Boolean"];
+}
+
 export interface ICoin {
    __typename?: "Coin";
   id: Scalars["String"];
@@ -374,6 +412,9 @@ export interface IQuery {
   fiatCurrencies: IFiatCurrency[];
   /** Oasis APIs */
   oasisTransactions: IOasisTransactionResult;
+  /** Celo APIs */
+  celoAccountHistory: ICeloAccountSnapshot[];
+  celoTransactions: ICeloTransactionResult;
 }
 
 export interface IQueryPortfolioHistoryArgs {
@@ -472,6 +513,17 @@ export interface IQueryPricesArgs {
 }
 
 export interface IQueryOasisTransactionsArgs {
+  address: Scalars["String"];
+  startingPage: Maybe<Scalars["Float"]>;
+  pageSize: Maybe<Scalars["Float"]>;
+}
+
+export interface IQueryCeloAccountHistoryArgs {
+  address: Scalars["String"];
+  fiat: Scalars["String"];
+}
+
+export interface IQueryCeloTransactionsArgs {
   address: Scalars["String"];
   startingPage: Maybe<Scalars["Float"]>;
   pageSize: Maybe<Scalars["Float"]>;
@@ -699,6 +751,41 @@ export type IAccountInformationQuery = (
         & Pick<IPubKey, "type">
       )> }
     ) }
+  ) }
+);
+
+export interface ICeloAccountHistoryQueryVariables {
+  address: Scalars["String"];
+  fiat: Scalars["String"];
+}
+
+export type ICeloAccountHistoryQuery = (
+  { __typename?: "Query" }
+  & { celoAccountHistory: Array<(
+    { __typename?: "CeloAccountSnapshot" }
+    & Pick<ICeloAccountSnapshot, "snapshotDate" | "address" | "height" | "snapshotReward" | "goldTokenBalance" | "totalLockedGoldBalance" | "nonVotingLockedGoldBalance" | "votingLockedGoldBalance" | "pendingWithdrawalBalance" | "celoUSDValue">
+    & { delegations: Array<(
+      { __typename?: "CeloDelegation" }
+      & Pick<ICeloDelegation, "group" | "totalVotes" | "activeVotes" | "pendingVotes">
+    )> }
+  )> }
+);
+
+export interface ICeloTransactionsQueryVariables {
+  address: Scalars["String"];
+  startingPage: Maybe<Scalars["Float"]>;
+  pageSize: Maybe<Scalars["Float"]>;
+}
+
+export type ICeloTransactionsQuery = (
+  { __typename?: "Query" }
+  & { celoTransactions: (
+    { __typename?: "CeloTransactionResult" }
+    & Pick<ICeloTransactionResult, "page" | "limit" | "moreResultsExist">
+    & { data: Array<(
+      { __typename?: "CeloTransaction" }
+      & Pick<ICeloTransaction, "date" | "height">
+    )> }
   ) }
 );
 
@@ -1325,6 +1412,130 @@ export function useAccountInformationLazyQuery(baseOptions?: ApolloReactHooks.La
 export type AccountInformationQueryHookResult = ReturnType<typeof useAccountInformationQuery>;
 export type AccountInformationLazyQueryHookResult = ReturnType<typeof useAccountInformationLazyQuery>;
 export type AccountInformationQueryResult = ApolloReactCommon.QueryResult<IAccountInformationQuery, IAccountInformationQueryVariables>;
+export const CeloAccountHistoryDocument = gql`
+    query celoAccountHistory($address: String!, $fiat: String!) {
+  celoAccountHistory(address: $address, fiat: $fiat) {
+    snapshotDate
+    address
+    height
+    snapshotReward
+    goldTokenBalance
+    totalLockedGoldBalance
+    nonVotingLockedGoldBalance
+    votingLockedGoldBalance
+    pendingWithdrawalBalance
+    celoUSDValue
+    delegations {
+      group
+      totalVotes
+      activeVotes
+      pendingVotes
+    }
+  }
+}
+    `;
+export type CeloAccountHistoryComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>, "query"> & ({ variables: ICeloAccountHistoryQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+export const CeloAccountHistoryComponent = (props: CeloAccountHistoryComponentProps) => (
+      <ApolloReactComponents.Query<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables> query={CeloAccountHistoryDocument} {...props} />
+    );
+
+export type ICeloAccountHistoryProps<TChildProps = {}> = ApolloReactHoc.DataProps<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables> & TChildProps;
+export function withCeloAccountHistory<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ICeloAccountHistoryQuery,
+  ICeloAccountHistoryQueryVariables,
+  ICeloAccountHistoryProps<TChildProps>>) {
+    return ApolloReactHoc.withQuery<TProps, ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables, ICeloAccountHistoryProps<TChildProps>>(CeloAccountHistoryDocument, {
+      alias: "celoAccountHistory",
+      ...operationOptions,
+    });
+}
+
+/**
+ * __useCeloAccountHistoryQuery__
+ *
+ * To run a query within a React component, call `useCeloAccountHistoryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCeloAccountHistoryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCeloAccountHistoryQuery({
+ *   variables: {
+ *      address: // value for 'address'
+ *      fiat: // value for 'fiat'
+ *   },
+ * });
+ */
+export function useCeloAccountHistoryQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>) {
+        return ApolloReactHooks.useQuery<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>(CeloAccountHistoryDocument, baseOptions);
+      }
+export function useCeloAccountHistoryLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>(CeloAccountHistoryDocument, baseOptions);
+        }
+export type CeloAccountHistoryQueryHookResult = ReturnType<typeof useCeloAccountHistoryQuery>;
+export type CeloAccountHistoryLazyQueryHookResult = ReturnType<typeof useCeloAccountHistoryLazyQuery>;
+export type CeloAccountHistoryQueryResult = ApolloReactCommon.QueryResult<ICeloAccountHistoryQuery, ICeloAccountHistoryQueryVariables>;
+export const CeloTransactionsDocument = gql`
+    query celoTransactions($address: String!, $startingPage: Float, $pageSize: Float) {
+  celoTransactions(address: $address, startingPage: $startingPage, pageSize: $pageSize) {
+    page
+    limit
+    data {
+      date
+      height
+    }
+    moreResultsExist
+  }
+}
+    `;
+export type CeloTransactionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>, "query"> & ({ variables: ICeloTransactionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+export const CeloTransactionsComponent = (props: CeloTransactionsComponentProps) => (
+      <ApolloReactComponents.Query<ICeloTransactionsQuery, ICeloTransactionsQueryVariables> query={CeloTransactionsDocument} {...props} />
+    );
+
+export type ICeloTransactionsProps<TChildProps = {}> = ApolloReactHoc.DataProps<ICeloTransactionsQuery, ICeloTransactionsQueryVariables> & TChildProps;
+export function withCeloTransactions<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ICeloTransactionsQuery,
+  ICeloTransactionsQueryVariables,
+  ICeloTransactionsProps<TChildProps>>) {
+    return ApolloReactHoc.withQuery<TProps, ICeloTransactionsQuery, ICeloTransactionsQueryVariables, ICeloTransactionsProps<TChildProps>>(CeloTransactionsDocument, {
+      alias: "celoTransactions",
+      ...operationOptions,
+    });
+}
+
+/**
+ * __useCeloTransactionsQuery__
+ *
+ * To run a query within a React component, call `useCeloTransactionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCeloTransactionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCeloTransactionsQuery({
+ *   variables: {
+ *      address: // value for 'address'
+ *      startingPage: // value for 'startingPage'
+ *      pageSize: // value for 'pageSize'
+ *   },
+ * });
+ */
+export function useCeloTransactionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>) {
+        return ApolloReactHooks.useQuery<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>(CeloTransactionsDocument, baseOptions);
+      }
+export function useCeloTransactionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>(CeloTransactionsDocument, baseOptions);
+        }
+export type CeloTransactionsQueryHookResult = ReturnType<typeof useCeloTransactionsQuery>;
+export type CeloTransactionsLazyQueryHookResult = ReturnType<typeof useCeloTransactionsLazyQuery>;
+export type CeloTransactionsQueryResult = ApolloReactCommon.QueryResult<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>;
 export const CoinsDocument = gql`
     query coins {
   coins {

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -147,7 +147,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: false,
     supportsTransactionsHistory: false,
     supportsValidatorsList: false,
-    denominationSize: 1e12,
+    denominationSize: 1e18, // 1 cGLD = 1000000000000000000 wei
   },
 };
 

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -24,6 +24,7 @@ export interface NetworkDefinition extends NetworkFeatureMeta {
   supportsLedger: boolean;
   ledgerAppName: string;
   ledgerDocsLink: string;
+  denominationSize: number;
 }
 
 interface NetworksMap {
@@ -63,6 +64,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: true,
     supportsTransactionsHistory: true,
     supportsValidatorsList: true,
+    denominationSize: 1e6,
   },
   TERRA: {
     available: true,
@@ -82,6 +84,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: false,
     supportsTransactionsHistory: false,
     supportsValidatorsList: true,
+    denominationSize: 1e6,
   },
   KAVA: {
     available: true,
@@ -102,6 +105,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: false,
     supportsTransactionsHistory: false,
     supportsValidatorsList: true,
+    denominationSize: 1e6,
   },
   OASIS: {
     available: false,
@@ -121,6 +125,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: false,
     supportsTransactionsHistory: true,
     supportsValidatorsList: false,
+    denominationSize: 1e6,
   },
   CELO: {
     // available: true,
@@ -138,10 +143,11 @@ const NETWORKS: NetworksMap = {
     // supportsLedger: true,
     supportsLedger: false,
     supportsFiatPrices: false,
-    supportsBalances: false,
+    supportsBalances: true,
     supportsPortfolio: false,
     supportsTransactionsHistory: false,
     supportsValidatorsList: false,
+    denominationSize: 1e12,
   },
 };
 

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -64,7 +64,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: true,
     supportsTransactionsHistory: true,
     supportsValidatorsList: true,
-    denominationSize: 1e6,
+    denominationSize: 1e6, // 1 ATOM = 1,000,000 uatom
   },
   TERRA: {
     available: true,
@@ -125,7 +125,7 @@ const NETWORKS: NetworksMap = {
     supportsPortfolio: false,
     supportsTransactionsHistory: true,
     supportsValidatorsList: false,
-    denominationSize: 1e6,
+    denominationSize: 1e6, // TODO: What is the denomination size?
   },
   CELO: {
     // available: true,


### PR DESCRIPTION
**This PR:**

* Connect the Anthem backend to the Celo Icarus extractor APIs for account balances and account history.
* Implement basic account balances for Celo using the existing account balances UI (this will probably have to change because the Celo balances are very different than Cosmos).
* Refactor `currency-utils` to work in a more generic network-specific way.