### PR TITLE
Celo & Oasis Network Integrations Updates

### DIFF
--- a/packages/client/src/components/Balances.tsx
+++ b/packages/client/src/components/Balances.tsx
@@ -265,7 +265,7 @@ class CosmosBalances extends React.Component<CosmosBalancesProps> {
           <ActionContainer>
             <H5>{tString("What do you want to do?")}</H5>
             <DelegationControlsContainer>
-              <Link to="/staking">
+              <Link to="/delegate">
                 <Button
                   style={{ width: 125, marginRight: 12 }}
                   onClick={() => null}

--- a/packages/client/src/components/Balances.tsx
+++ b/packages/client/src/components/Balances.tsx
@@ -53,6 +53,7 @@ class Balance extends React.Component<IProps, {}> {
       ledger,
       accountBalances,
     } = this.props;
+    console.log(accountBalances);
     const { tString } = i18n;
     const { network } = ledger;
     const { isDesktop, currencySetting } = settings;
@@ -304,7 +305,7 @@ class CeloBalances extends React.Component<CeloBalancesProps> {
     const { balances, network } = this.props;
 
     const {
-      goldTokenBalance,
+      availableGoldBalance,
       totalLockedGoldBalance,
       // nonVotingLockedGoldBalance,
       // votingLockedGoldBalance,
@@ -320,13 +321,13 @@ class CeloBalances extends React.Component<CeloBalancesProps> {
     };
 
     const total = addValuesInList([
-      goldTokenBalance,
+      availableGoldBalance,
       totalLockedGoldBalance,
       pendingWithdrawalBalance,
     ]);
 
     const percentages: number[] = [
-      getPercentage(goldTokenBalance, total),
+      getPercentage(availableGoldBalance, total),
       getPercentage(totalLockedGoldBalance, total),
       getPercentage(pendingWithdrawalBalance, total),
     ];
@@ -344,7 +345,7 @@ class CeloBalances extends React.Component<CeloBalancesProps> {
                 />
                 <BalanceTitle>Gold Balance:</BalanceTitle>
                 <BalanceText data-cy="celo-gold-balance-available">
-                  {renderCurrency(goldTokenBalance)}
+                  {renderCurrency(availableGoldBalance)}
                 </BalanceText>
               </BalanceLine>
               <BalanceLine>

--- a/packages/client/src/components/Balances.tsx
+++ b/packages/client/src/components/Balances.tsx
@@ -53,7 +53,6 @@ class Balance extends React.Component<IProps, {}> {
       ledger,
       accountBalances,
     } = this.props;
-    console.log(accountBalances);
     const { tString } = i18n;
     const { network } = ledger;
     const { isDesktop, currencySetting } = settings;

--- a/packages/client/src/components/LedgerDialogWorkflow.tsx
+++ b/packages/client/src/components/LedgerDialogWorkflow.tsx
@@ -6,7 +6,7 @@ import {
   Centered,
   Column,
   ErrorText,
-  Link,
+  Link as HrefLink,
   LoaderBars,
   Row,
   TextInput,
@@ -18,6 +18,7 @@ import Modules, { ReduxStoreState } from "modules/root";
 import { i18nSelector } from "modules/settings/selectors";
 import React, { ChangeEvent } from "react";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import styled, { CSSProperties } from "styled-components";
 import { formatAddressString, onPath } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
@@ -274,7 +275,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
           </Centered>
         )}
         {this.renderBackArrow()}
-        <Link
+        <HrefLink
           style={{
             right: 0,
             bottom: -16,
@@ -283,7 +284,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
           href={network.ledgerDocsLink}
         >
           <span>{network.ledgerAppName} App Docs</span>
-        </Link>
+        </HrefLink>
       </View>
     );
   };
@@ -298,6 +299,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
 
   renderAddressInputDialog = () => {
     const { tString } = this.props.i18n;
+    const { activeChartTab } = this.props.app;
     const { addressError, recentAddresses } = this.props.ledger;
     const currentAddress = this.props.ledger.address;
 
@@ -364,11 +366,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
                     <Link
                       key={address}
                       style={{ marginTop: 2, marginBottom: 2 }}
-                      onClick={() => {
-                        this.props.setAddress(address, {
-                          showToastForError: true,
-                        });
-                      }}
+                      to={`/${activeChartTab}?address=${address}`}
                     >
                       {formatAddressString(
                         address,
@@ -394,14 +392,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
               >
                 <Link
                   style={{ marginTop: 2, marginBottom: 2 }}
-                  onClick={() => {
-                    this.props.setAddress(
-                      "cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd",
-                      {
-                        showToastForError: true,
-                      },
-                    );
-                  }}
+                  to={`/${activeChartTab}?address=cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd`}
                 >
                   {formatAddressString(
                     "cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd",
@@ -576,6 +567,7 @@ const ClearAllLink = styled.p`
 const mapStateToProps = (state: ReduxStoreState) => ({
   i18n: i18nSelector(state),
   settings: Modules.selectors.settings(state),
+  app: Modules.selectors.app.appSelector(state),
   ledger: Modules.selectors.ledger.ledgerSelector(state),
   ledgerDialog: Modules.selectors.ledger.ledgerDialogSelector(state),
   transaction: Modules.selectors.transaction.transactionsSelector(state),

--- a/packages/client/src/components/SharedComponents.tsx
+++ b/packages/client/src/components/SharedComponents.tsx
@@ -146,11 +146,29 @@ export const LoaderBars = ({ style }: { style?: CSSProperties }) => (
  * DashboardLoader
  * ============================================================================
  */
-export const DashboardLoader = ({ style }: { style?: React.CSSProperties }) => (
+export const DashboardLoader = ({
+  style,
+  showPortfolioLoadingMessage,
+}: {
+  showPortfolioLoadingMessage?: boolean;
+  style?: React.CSSProperties;
+}) => (
   <View style={{ marginTop: 85, ...style }}>
     <Spinner />
+    {showPortfolioLoadingMessage && (
+      <LoadingWarningMessage>
+        <b>Notice:</b> Addresses with a large amount of activity take a while to
+        load.
+      </LoadingWarningMessage>
+    )}
   </View>
 );
+
+const LoadingWarningMessage = styled.p`
+  margin-top: 22px;
+  font-size: 14px;
+  text-align: center;
+`;
 
 /** ===========================================================================
  * Link

--- a/packages/client/src/components/SideMenu.tsx
+++ b/packages/client/src/components/SideMenu.tsx
@@ -31,7 +31,6 @@ import {
   copyTextToClipboard,
   onActiveRoute,
   onChartView,
-  onPath,
 } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import BetaBanner from "./BetaBanner";

--- a/packages/client/src/components/SideMenu.tsx
+++ b/packages/client/src/components/SideMenu.tsx
@@ -30,7 +30,6 @@ import {
   abbreviateAddress,
   copyTextToClipboard,
   onActiveRoute,
-  onChartView,
 } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import BetaBanner from "./BetaBanner";
@@ -44,7 +43,6 @@ import Toast from "./Toast";
 
 interface IState {
   mobileMenuOpen: boolean;
-  dashboardRoute: string; // TODO: Move to global state
 }
 
 /** ===========================================================================
@@ -58,21 +56,11 @@ class SideMenuComponent extends React.Component<IProps, IState> {
 
     this.state = {
       mobileMenuOpen: false,
-      dashboardRoute: "",
     };
   }
 
   componentDidMount() {
-    this.setDashboardTabRoute();
     this.setupMobileSwipeHandler();
-  }
-
-  componentDidUpdate() {
-    /**
-     * Update the current dashboard tab route whenever SideMenuComponent
-     * re-renders.
-     */
-    this.setDashboardTabRoute();
   }
 
   render(): JSX.Element {
@@ -86,7 +74,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
     const open = () => this.setMobileMenuState(true);
     const close = () => this.setMobileMenuState(false);
 
-    const dashboardTab = this.state.dashboardRoute;
+    const dashboardTab = this.props.app.activeChartTab;
     const ledgerConnected = this.props.ledger.connected;
     const validator = this.getValidatorFromDelegatorAddressIfExists();
 
@@ -267,7 +255,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
       return (
         <DesktopNavigationContainer className={Classes.DARK}>
           <View>
-            <Link to={`/${this.state.dashboardRoute}`}>
+            <Link to={`/${this.props.app.activeChartTab}`}>
               <BetaBanner mobile={false} />
               <ChorusTitleImage src={ChorusLogo} alt="Chorus One Logo" />
             </Link>
@@ -318,17 +306,6 @@ class SideMenuComponent extends React.Component<IProps, IState> {
     this.setState({
       mobileMenuOpen: state,
     });
-  };
-
-  setDashboardTabRoute = () => {
-    const { pathname } = this.props.location;
-    const onDashboard = onChartView(pathname);
-    const dashboardTab = pathname.split("/")[1];
-    if (onDashboard) {
-      if (dashboardTab !== this.state.dashboardRoute) {
-        this.setState({ dashboardRoute: dashboardTab });
-      }
-    }
   };
 
   onCopySuccess = () => {

--- a/packages/client/src/components/SideMenu.tsx
+++ b/packages/client/src/components/SideMenu.tsx
@@ -30,6 +30,7 @@ import {
   abbreviateAddress,
   copyTextToClipboard,
   onActiveRoute,
+  onChartView,
   onPath,
 } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
@@ -44,7 +45,7 @@ import Toast from "./Toast";
 
 interface IState {
   mobileMenuOpen: boolean;
-  dashboardRoute: string;
+  dashboardRoute: string; // TODO: Move to global state
 }
 
 /** ===========================================================================
@@ -98,7 +99,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         path={pathname}
         closeHandler={close}
         key="Dashboard"
-        route={`Dashboard${dashboardTab}`}
+        route={`${dashboardTab}`}
         title={tString("Dashboard")}
         icon={IconNames.TIMELINE_BAR_CHART}
       />,
@@ -106,7 +107,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         path={pathname}
         closeHandler={close}
         key="Staking"
-        route="Staking"
+        route="Delegate"
         title="Staking"
         icon={IconNames.BANK_ACCOUNT}
       />,
@@ -267,7 +268,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
       return (
         <DesktopNavigationContainer className={Classes.DARK}>
           <View>
-            <Link to="/dashboard">
+            <Link to={`/${this.state.dashboardRoute}`}>
               <BetaBanner mobile={false} />
               <ChorusTitleImage src={ChorusLogo} alt="Chorus One Logo" />
             </Link>
@@ -322,10 +323,9 @@ class SideMenuComponent extends React.Component<IProps, IState> {
 
   setDashboardTabRoute = () => {
     const { pathname } = this.props.location;
-    const onDashboard = onPath(pathname, "/dashboard");
-    let dashboardTab = "";
+    const onDashboard = onChartView(pathname);
+    const dashboardTab = pathname.split("/")[1];
     if (onDashboard) {
-      dashboardTab = pathname.replace("/dashboard", "");
       if (dashboardTab !== this.state.dashboardRoute) {
         this.setState({ dashboardRoute: dashboardTab });
       }

--- a/packages/client/src/components/SideMenu.tsx
+++ b/packages/client/src/components/SideMenu.tsx
@@ -435,7 +435,7 @@ interface INavItemProps {
 }
 
 const NavItem = ({ route, title, icon, path, closeHandler }: INavItemProps) => {
-  const active = onActiveRoute(path, title);
+  const active = onActiveRoute(path, route);
   const cypressLabel = `${title.toLowerCase()}-navigation-link`;
   return (
     <Link

--- a/packages/client/src/containers/AppContainer.tsx
+++ b/packages/client/src/containers/AppContainer.tsx
@@ -58,14 +58,13 @@ class AppContainer extends React.Component<IProps, IState> {
 
   componentDidUpdate(prevProps: IProps) {
     // Update the address param in the url when the address changes.
-    const queryParams = getQueryParamsFromUrl(prevProps.location.search);
-    const maybeAddress = queryParams.address;
-
-    if (maybeAddress === undefined) {
-      this.setAddressQueryParams(this.props);
-    } else if (maybeAddress !== this.props.ledger.address) {
-      this.setAddressQueryParams(this.props);
-    }
+    // const queryParams = getQueryParamsFromUrl(prevProps.location.search);
+    // const maybeAddress = queryParams.address;
+    // if (maybeAddress === undefined) {
+    //   this.setAddressQueryParams(this.props);
+    // } else if (maybeAddress !== this.props.ledger.address) {
+    //   this.setAddressQueryParams(this.props);
+    // }
   }
 
   render(): Nullable<JSX.Element> {
@@ -100,7 +99,7 @@ class AppContainer extends React.Component<IProps, IState> {
     const { address } = props.ledger;
     // Only set the current address param if the user is on a /dashboard route.
     if (!!address && onPath(location.pathname, "/dashboard")) {
-      const search = `?address=${address}&page=${transactionPage}`;
+      // const search = `?address=${address}&page=${transactionPage}`;
       // if (search !== location.search) {
       //   this.props.history.replace({
       //     search,

--- a/packages/client/src/containers/AppContainer.tsx
+++ b/packages/client/src/containers/AppContainer.tsx
@@ -101,12 +101,12 @@ class AppContainer extends React.Component<IProps, IState> {
     // Only set the current address param if the user is on a /dashboard route.
     if (!!address && onPath(location.pathname, "/dashboard")) {
       const search = `?address=${address}&page=${transactionPage}`;
-      if (search !== location.search) {
-        this.props.history.push({
-          search,
-          pathname: props.location.pathname,
-        });
-      }
+      // if (search !== location.search) {
+      //   this.props.history.replace({
+      //     search,
+      //     pathname: props.location.pathname,
+      //   });
+      // }
     }
   };
 

--- a/packages/client/src/containers/AppContainer.tsx
+++ b/packages/client/src/containers/AppContainer.tsx
@@ -149,7 +149,7 @@ const mapStateToProps = (state: ReduxStoreState) => ({
 
 const dispatchProps = {
   initializeApp: Modules.actions.app.initializeApp,
-  onRouteChange: Modules.actions.settings.onRouteChange,
+  onRouteChange: Modules.actions.app.onRouteChange,
 };
 
 type ConnectProps = ReturnType<typeof mapStateToProps> & typeof dispatchProps;

--- a/packages/client/src/containers/AppContainer.tsx
+++ b/packages/client/src/containers/AppContainer.tsx
@@ -116,8 +116,6 @@ const ErrorText = styled.p`
 const mapStateToProps = (state: ReduxStoreState) => ({
   i18n: i18nSelector(state),
   loading: Modules.selectors.app.loadingSelector(state),
-  ledger: Modules.selectors.ledger.ledgerSelector(state),
-  transactionPage: Modules.selectors.transaction.transactionsPage(state),
 });
 
 const dispatchProps = {

--- a/packages/client/src/containers/AppContainer.tsx
+++ b/packages/client/src/containers/AppContainer.tsx
@@ -10,7 +10,6 @@ import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import styled from "styled-components";
-import { getQueryParamsFromUrl, onPath } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import RoutesContainer, { FixedAppBackgroundPage } from "./RoutesContainer";
 
@@ -56,17 +55,6 @@ class AppContainer extends React.Component<IProps, IState> {
     Sentry.captureException(error);
   }
 
-  componentDidUpdate(prevProps: IProps) {
-    // Update the address param in the url when the address changes.
-    // const queryParams = getQueryParamsFromUrl(prevProps.location.search);
-    // const maybeAddress = queryParams.address;
-    // if (maybeAddress === undefined) {
-    //   this.setAddressQueryParams(this.props);
-    // } else if (maybeAddress !== this.props.ledger.address) {
-    //   this.setAddressQueryParams(this.props);
-    // }
-  }
-
   render(): Nullable<JSX.Element> {
     if (!this.props.loading.initialized) {
       return null;
@@ -92,21 +80,6 @@ class AppContainer extends React.Component<IProps, IState> {
         </Centered>
       </ErrorFallbackPage>
     );
-  };
-
-  setAddressQueryParams = (props: IProps) => {
-    const { location, transactionPage } = props;
-    const { address } = props.ledger;
-    // Only set the current address param if the user is on a /dashboard route.
-    if (!!address && onPath(location.pathname, "/dashboard")) {
-      // const search = `?address=${address}&page=${transactionPage}`;
-      // if (search !== location.search) {
-      //   this.props.history.replace({
-      //     search,
-      //     pathname: props.location.pathname,
-      //   });
-      // }
-    }
   };
 
   routeChangeListener = (location: Location, action: Action) => {

--- a/packages/client/src/containers/RoutesContainer.tsx
+++ b/packages/client/src/containers/RoutesContainer.tsx
@@ -69,10 +69,10 @@ class RoutesContainer extends React.Component<IProps> {
             {/* <Route key={0} exact path="/login" component={LandingPage} /> */}
             {/* <Route key={1} path="/welcome" component={DashboardPage} /> */}
             <Route
-              key={2}
               exact
-              path="/:path(total|available|staking|rewards|commissions)"
+              key={2}
               component={DashboardPage}
+              path="/:path(total|available|staking|rewards|commissions)"
             />
             <Route
               key={3}

--- a/packages/client/src/containers/RoutesContainer.tsx
+++ b/packages/client/src/containers/RoutesContainer.tsx
@@ -71,7 +71,7 @@ class RoutesContainer extends React.Component<IProps> {
             <Route
               key={2}
               exact
-              path="/:path(total|available|staking|rewards|commissions)/*"
+              path="/:path(total|available|staking|rewards|commissions)"
               component={DashboardPage}
             />
             <Route
@@ -86,7 +86,7 @@ class RoutesContainer extends React.Component<IProps> {
               key={7}
               component={() =>
                 !!address ? (
-                  <Redirect to="/total/" />
+                  <Redirect to="/total" />
                 ) : (
                   <Redirect to="/welcome" />
                 )

--- a/packages/client/src/containers/RoutesContainer.tsx
+++ b/packages/client/src/containers/RoutesContainer.tsx
@@ -86,7 +86,7 @@ class RoutesContainer extends React.Component<IProps> {
               key={7}
               component={() =>
                 !!address ? (
-                  <Redirect to="/total" />
+                  <Redirect to="/total/" />
                 ) : (
                   <Redirect to="/welcome" />
                 )

--- a/packages/client/src/containers/RoutesContainer.tsx
+++ b/packages/client/src/containers/RoutesContainer.tsx
@@ -71,7 +71,7 @@ class RoutesContainer extends React.Component<IProps> {
             <Route
               key={2}
               exact
-              path="/dashboard/*"
+              path="/:path(total|available|staking|rewards|commissions)/*"
               component={DashboardPage}
             />
             <Route
@@ -79,14 +79,14 @@ class RoutesContainer extends React.Component<IProps> {
               path="/txs/*"
               component={TransactionDetailContainer}
             />
-            <Route key={4} path="/staking" component={ValidatorsListPage} />
+            <Route key={4} path="/delegate" component={ValidatorsListPage} />
             <Route key={5} path="/help" component={HelpPage} />
             <Route key={6} path="/settings" component={SettingsPage} />
             <Route
               key={7}
               component={() =>
                 !!address ? (
-                  <Redirect to="/dashboard/total" />
+                  <Redirect to="/total" />
                 ) : (
                   <Redirect to="/welcome" />
                 )

--- a/packages/client/src/graphql/queries.ts
+++ b/packages/client/src/graphql/queries.ts
@@ -360,7 +360,7 @@ interface CeloTransactionsQueryResult extends QueryResult {
   celoTransactions: IQuery["celoTransactions"];
 }
 
-export interface CeoTransactionsProps {
+export interface CeloTransactionsProps {
   transactions: CeloTransactionsQueryResult;
 }
 

--- a/packages/client/src/modules/app/actions.ts
+++ b/packages/client/src/modules/app/actions.ts
@@ -49,7 +49,7 @@ enum ActionTypesEnum {
  * ============================================================================
  */
 
-const empty = createStandardAction(ActionTypesEnum.EMPTY_ACTION)();
+const empty = createStandardAction(ActionTypesEnum.EMPTY_ACTION)<string>();
 
 const setDashboardAddressInputFocusState = createStandardAction(
   ActionTypesEnum.SET_DASHBOARD_ADDRESS_INPUT_FOCUS_STATE,

--- a/packages/client/src/modules/app/actions.ts
+++ b/packages/client/src/modules/app/actions.ts
@@ -1,4 +1,5 @@
 import { NetworkDefinition } from "@anthem/utils";
+import { Action, Location } from "history";
 import { ActionType, createStandardAction } from "typesafe-actions";
 import {
   BANNER_NOTIFICATIONS_KEYS,
@@ -39,6 +40,8 @@ enum ActionTypesEnum {
   SET_TRANSACTIONS_SIZE = "SET_TRANSACTIONS_SIZE",
 
   SET_ADDRESS_INPUT_REF = "SET_ADDRESS_INPUT_REF",
+
+  ROUTE_CHANGE = "ROUTE_CHANGE",
 }
 
 /** ===========================================================================
@@ -112,6 +115,14 @@ const setAddressInputRef = createStandardAction(
   ActionTypesEnum.SET_ADDRESS_INPUT_REF,
 )<Nullable<HTMLInputElement>>();
 
+interface RouteInformation extends Location {
+  action: Action;
+}
+
+const onRouteChange = createStandardAction(ActionTypesEnum.ROUTE_CHANGE)<
+  RouteInformation
+>();
+
 const actions = {
   empty,
   initializeApp,
@@ -131,6 +142,7 @@ const actions = {
   togglePortfolioSize,
   toggleTransactionsSize,
   setAddressInputRef,
+  onRouteChange,
 };
 
 /** ===========================================================================

--- a/packages/client/src/modules/app/actions.ts
+++ b/packages/client/src/modules/app/actions.ts
@@ -83,7 +83,7 @@ const refreshBalanceAndTransactionsSuccess = createStandardAction(
 )();
 
 const initializeApp = createStandardAction(ActionTypesEnum.INITIALIZING_APP)();
-const initializeSuccess = createStandardAction(
+const initializeAppSuccess = createStandardAction(
   ActionTypesEnum.INITIALIZING_APP_SUCCESS,
 )<{ address: string; network: NetworkDefinition; page: number }>();
 
@@ -126,7 +126,7 @@ const onRouteChange = createStandardAction(ActionTypesEnum.ROUTE_CHANGE)<
 const actions = {
   empty,
   initializeApp,
-  initializeSuccess,
+  initializeAppSuccess,
   newsletterSignup,
   newsletterSignupSuccess,
   newsletterSignupFailure,

--- a/packages/client/src/modules/app/actions.ts
+++ b/packages/client/src/modules/app/actions.ts
@@ -42,6 +42,8 @@ enum ActionTypesEnum {
   SET_ADDRESS_INPUT_REF = "SET_ADDRESS_INPUT_REF",
 
   ROUTE_CHANGE = "ROUTE_CHANGE",
+
+  SET_ACTIVE_CHART_TAB = "SET_ACTIVE_CHART_TAB",
 }
 
 /** ===========================================================================
@@ -123,6 +125,10 @@ const onRouteChange = createStandardAction(ActionTypesEnum.ROUTE_CHANGE)<
   RouteInformation
 >();
 
+const setActiveChartTab = createStandardAction(
+  ActionTypesEnum.SET_ACTIVE_CHART_TAB,
+)<string>();
+
 const actions = {
   empty,
   initializeApp,
@@ -143,6 +149,7 @@ const actions = {
   toggleTransactionsSize,
   setAddressInputRef,
   onRouteChange,
+  setActiveChartTab,
 };
 
 /** ===========================================================================

--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -70,7 +70,7 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
       const paramsPage = Number(params.page);
       const page = !isNaN(paramsPage) ? paramsPage : 1;
 
-      return Actions.initializeSuccess({
+      return Actions.initializeAppSuccess({
         address,
         network,
         page,
@@ -81,7 +81,9 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
 
 const maybeResetCurrencySettingEpic: EpicSignature = (action$, state$) => {
   return action$.pipe(
-    filter(isActionOf([Actions.setAddressSuccess, Actions.initializeSuccess])),
+    filter(
+      isActionOf([Actions.setAddressSuccess, Actions.initializeAppSuccess]),
+    ),
     filter(() => {
       return (
         state$.value.settings.currencySetting === "fiat" &&
@@ -98,7 +100,9 @@ const maybeResetCurrencySettingEpic: EpicSignature = (action$, state$) => {
 
 const monthlySummaryEmailBannerEpic: EpicSignature = (action$, state$) => {
   return action$.pipe(
-    filter(isActionOf([Actions.setAddressSuccess, Actions.initializeSuccess])),
+    filter(
+      isActionOf([Actions.setAddressSuccess, Actions.initializeAppSuccess]),
+    ),
     filter(() => {
       // Make development easier, whatever...
       if (ENV.ENABLE_MOCK_APIS) {

--- a/packages/client/src/modules/app/store.ts
+++ b/packages/client/src/modules/app/store.ts
@@ -136,7 +136,7 @@ const app = createReducer<AppState, ActionTypes>(initialAppState)
   )
   .handleAction(actions.onRouteChange, (state, action) => ({
     ...state,
-    routePathname: {
+    locationState: {
       search: action.payload.search,
       pathname: action.payload.pathname,
     },

--- a/packages/client/src/modules/app/store.ts
+++ b/packages/client/src/modules/app/store.ts
@@ -20,7 +20,7 @@ const initialState = {
 };
 
 const loading = createReducer<LoadingState, ActionTypes>(initialState)
-  .handleAction(actions.initializeSuccess, (state, action) => ({
+  .handleAction(actions.initializeAppSuccess, (state, action) => ({
     ...state,
     initialized: true,
   }))

--- a/packages/client/src/modules/app/store.ts
+++ b/packages/client/src/modules/app/store.ts
@@ -1,3 +1,4 @@
+import { Pathname, Search } from "history";
 import StorageModule from "lib/storage-lib";
 import { combineReducers } from "redux";
 import { createReducer } from "typesafe-actions";
@@ -66,9 +67,13 @@ interface AppState {
   transactionsExpanded: boolean;
   portfolioExpanded: boolean;
   addressInputRef: Nullable<HTMLInputElement>;
+  locationState: {
+    pathname: Pathname;
+    search: Search;
+  };
 }
 
-const initialAppState = {
+const initialAppState: AppState = {
   activeBannerKey: null,
   showDataIntegrityHelpLabel: false,
   dashboardInputFocused: false,
@@ -80,6 +85,10 @@ const initialAppState = {
   transactionsExpanded: false,
   portfolioExpanded: false,
   addressInputRef: null,
+  locationState: {
+    pathname: "",
+    search: "",
+  },
 };
 
 const app = createReducer<AppState, ActionTypes>(initialAppState)
@@ -125,6 +134,13 @@ const app = createReducer<AppState, ActionTypes>(initialAppState)
       dashboardInputFocused: action.payload,
     }),
   )
+  .handleAction(actions.onRouteChange, (state, action) => ({
+    ...state,
+    routePathname: {
+      search: action.payload.search,
+      pathname: action.payload.pathname,
+    },
+  }))
   .handleAction(actions.toggleNotificationsBanner, (state, { payload }) => ({
     ...state,
     activeBannerKey: payload.visible ? payload.key : null,

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -272,6 +272,10 @@ const saveAddressEpic: EpicSignature = action$ => {
   );
 };
 
+/**
+ * Set the address from routing events, if they routed address is
+ * different from the stored address.
+ */
 const setAddressOnNavigationEpic: EpicSignature = (action$, state$, deps) => {
   return action$.pipe(
     filter(isActionOf(Actions.onRouteChange)),
@@ -289,7 +293,10 @@ const setAddressOnNavigationEpic: EpicSignature = (action$, state$, deps) => {
   );
 };
 
-const setAddressParamsOnNavigationEpic: EpicSignature = (
+/**
+ * Sync the address to the url after navigation events.
+ */
+const syncAddressToUrlOnNavigationEpic: EpicSignature = (
   action$,
   state$,
   deps,
@@ -315,7 +322,10 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
   );
 };
 
-const setAddressParamsOnInitializeEpic: EpicSignature = (
+/**
+ * Sync the address to the url when the app initializes.
+ */
+const syncAddressToUrlOnInitializationEpic: EpicSignature = (
   action$,
   state$,
   deps,
@@ -333,6 +343,7 @@ const setAddressParamsOnInitializeEpic: EpicSignature = (
       if (!onChartView(pathname)) {
         return;
       }
+
       if (pathAddress !== address) {
         deps.router.replace({
           search,
@@ -399,8 +410,8 @@ export default combineEpics(
   logoutEpic,
   saveAddressEpic,
   setAddressNavigationEpic,
-  setAddressParamsOnNavigationEpic,
-  setAddressParamsOnInitializeEpic,
+  syncAddressToUrlOnNavigationEpic,
+  syncAddressToUrlOnInitializationEpic,
   setAddressOnNavigationEpic,
   searchTransactionNavigationEpic,
   clearAllRecentAddressesEpic,

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -316,9 +316,7 @@ const syncAddressToUrlOnNavigationEpic: EpicSignature = (
           ? `?address=${address}&page=${transactionsPage}`
           : `?address=${address}`;
 
-      console.log(location.search);
-      console.log(search);
-      if (search !== location.search && onChartView(pathname)) {
+      if (!!address && search !== location.search && onChartView(pathname)) {
         deps.router.replace({ search });
       }
     }),
@@ -416,7 +414,7 @@ export default combineEpics(
   // setAddressNavigationEpic,
   syncAddressToUrlOnNavigationEpic,
   syncAddressToUrlOnInitializationEpic,
-  setAddressOnNavigationEpic,
+  // setAddressOnNavigationEpic,
   searchTransactionNavigationEpic,
   clearAllRecentAddressesEpic,
 );

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -301,11 +301,11 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
       const { address } = state$.value.ledger.ledger;
       const { transactionsPage } = state$.value.transaction;
       const { pathname } = state$.value.app.app.locationState;
-      const search = `?page=${transactionsPage}`;
-
+      const search = transactionsPage > 1 ? `?page=${transactionsPage}` : "";
       const path = pathname.split("/")[1];
       const pathAddress = pathname.split("/")[2];
       if (!!address && pathAddress !== address && onChartView(pathname)) {
+        console.log("REPLACING!");
         deps.router.replace({
           search,
           pathname: `/${path}/${address}`,
@@ -334,7 +334,6 @@ const setAddressParamsOnInitializeEpic: EpicSignature = (
       if (!onChartView(pathname)) {
         return;
       }
-
       if (pathAddress !== address) {
         deps.router.replace({
           search,

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -283,7 +283,7 @@ const setAddressOnNavigationEpic: EpicSignature = (action$, state$, deps) => {
       if (typeof address === "string" && address !== ledger.ledger.address) {
         return Actions.setAddress(address, { showToastForError: false });
       } else {
-        return Actions.empty();
+        return Actions.empty("No action taken to update location query params");
       }
     }),
   );

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -288,6 +288,51 @@ const setAddressOnNavigationEpic: EpicSignature = (action$, state$, deps) => {
   );
 };
 
+const setAddressParamsOnNavigationEpic: EpicSignature = (
+  action$,
+  state$,
+  deps,
+) => {
+  return action$.pipe(
+    filter(isActionOf(Actions.onRouteChange)),
+    pluck("payload"),
+    tap(payload => {
+      const { address } = state$.value.ledger.ledger;
+      const { transactionsPage } = state$.value.transaction;
+      const search = `?address=${address}&page=${transactionsPage}`;
+      if (search !== payload.search) {
+        deps.router.replace({
+          search,
+          pathname: deps.router.location.pathname,
+        });
+      }
+    }),
+    ignoreElements(),
+  );
+};
+
+const setAddressParamsOnInitializeEpic: EpicSignature = (
+  action$,
+  state$,
+  deps,
+) => {
+  return action$.pipe(
+    filter(isActionOf(Actions.initializeSuccess)),
+    pluck("payload"),
+    pluck("address"),
+    tap(payload => {
+      const { address } = state$.value.ledger.ledger;
+      const { transactionsPage } = state$.value.transaction;
+      const search = `?address=${address}&page=${transactionsPage}`;
+      deps.router.replace({
+        search,
+        pathname: deps.router.location.pathname,
+      });
+    }),
+    ignoreElements(),
+  );
+};
+
 const setAddressNavigationEpic: EpicSignature = (action$, state$, deps) => {
   return action$.pipe(
     filter(isActionOf(Actions.setAddressSuccess)),
@@ -338,6 +383,8 @@ export default combineEpics(
   logoutEpic,
   saveAddressEpic,
   setAddressNavigationEpic,
+  setAddressParamsOnNavigationEpic,
+  setAddressParamsOnInitializeEpic,
   setAddressOnNavigationEpic,
   searchTransactionNavigationEpic,
   clearAllRecentAddressesEpic,

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -325,7 +325,7 @@ const setAddressParamsOnInitializeEpic: EpicSignature = (
     filter(isActionOf(Actions.initializeAppSuccess)),
     pluck("payload"),
     pluck("address"),
-    tap(payload => {
+    tap(() => {
       const { address } = state$.value.ledger.ledger;
       const { transactionsPage } = state$.value.transaction;
       const search = `?address=${address}&page=${transactionsPage}`;

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -305,7 +305,6 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
       const path = pathname.split("/")[1];
       const pathAddress = pathname.split("/")[2];
       if (!!address && pathAddress !== address && onChartView(pathname)) {
-        console.log("REPLACING!");
         deps.router.replace({
           search,
           pathname: `/${path}/${address}`,

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -25,6 +25,7 @@ import { connectCeloAddress } from "tools/celo-ledger-utils";
 import {
   capitalizeString,
   getQueryParamsFromUrl,
+  onPath,
   wait,
 } from "tools/client-utils";
 import { getAccAddress } from "tools/terra-library/key-utils";
@@ -299,12 +300,16 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
     tap(payload => {
       const { address } = state$.value.ledger.ledger;
       const { transactionsPage } = state$.value.transaction;
+      const { pathname } = state$.value.app.app.locationState;
       const search = `?address=${address}&page=${transactionsPage}`;
-      if (search !== payload.search) {
-        deps.router.replace({
-          search,
-          pathname: deps.router.location.pathname,
-        });
+      // Apply only on dashboard route
+      if (!!address && onPath(pathname, "/dashboard")) {
+        if (search !== payload.search) {
+          deps.router.replace({
+            search,
+            pathname: deps.router.location.pathname,
+          });
+        }
       }
     }),
     ignoreElements(),

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -26,7 +26,6 @@ import {
   capitalizeString,
   getQueryParamsFromUrl,
   onChartView,
-  onPath,
   wait,
 } from "tools/client-utils";
 import { getAccAddress } from "tools/terra-library/key-utils";

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -303,7 +303,6 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
       const { pathname } = state$.value.app.app.locationState;
       const search = `?address=${address}&page=${transactionsPage}`;
       // Apply only on dashboard route
-      console.log(pathname);
       if (!!address && onPath(pathname, "/dashboard")) {
         if (search !== payload.search) {
           deps.router.replace({
@@ -323,7 +322,7 @@ const setAddressParamsOnInitializeEpic: EpicSignature = (
   deps,
 ) => {
   return action$.pipe(
-    filter(isActionOf(Actions.initializeSuccess)),
+    filter(isActionOf(Actions.initializeAppSuccess)),
     pluck("payload"),
     pluck("address"),
     tap(payload => {

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -303,6 +303,7 @@ const setAddressParamsOnNavigationEpic: EpicSignature = (
       const { pathname } = state$.value.app.app.locationState;
       const search = `?address=${address}&page=${transactionsPage}`;
       // Apply only on dashboard route
+      console.log(pathname);
       if (!!address && onPath(pathname, "/dashboard")) {
         if (search !== payload.search) {
           deps.router.replace({

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -308,14 +308,14 @@ const syncAddressToUrlOnNavigationEpic: EpicSignature = (
       const { address } = state$.value.ledger.ledger;
       const { transactionsPage } = state$.value.transaction;
       const { pathname } = state$.value.app.app.locationState;
-      const search = transactionsPage > 1 ? `?page=${transactionsPage}` : "";
-      const path = pathname.split("/")[1];
-      const pathAddress = pathname.split("/")[2];
+      const params = getQueryParamsFromUrl(pathname);
+      const pathAddress = params.address;
+      const search =
+        transactionsPage > 1
+          ? `page=${transactionsPage}`
+          : `address=${address}`;
       if (!!address && pathAddress !== address && onChartView(pathname)) {
-        deps.router.replace({
-          search,
-          pathname: `/${path}/${address}`,
-        });
+        deps.router.replace({ search });
       }
     }),
     ignoreElements(),
@@ -337,22 +337,16 @@ const syncAddressToUrlOnInitializationEpic: EpicSignature = (
     tap(() => {
       const { address } = state$.value.ledger.ledger;
       const { transactionsPage } = state$.value.transaction;
-      const search = `?page=${transactionsPage}`;
+      const search = `?address=${address}page=${transactionsPage}`;
       const { pathname } = deps.router.location;
       const pathAddress = pathname.split("/")[2];
       if (!onChartView(pathname)) {
         return;
       }
 
-      if (pathAddress !== address) {
+      if (pathAddress !== address || !pathname.includes(address)) {
         deps.router.replace({
           search,
-          pathname: `${deps.router.location.pathname}/${pathAddress}`,
-        });
-      } else if (!pathname.includes(address)) {
-        deps.router.replace({
-          search,
-          pathname: `${deps.router.location.pathname}/${address}`,
         });
       }
     }),
@@ -369,8 +363,7 @@ const setAddressNavigationEpic: EpicSignature = (action$, state$, deps) => {
       const { router } = deps;
       const page = state$.value.transaction.transactionsPage;
       router.push({
-        search: `page=${page}`,
-        pathname: `/total/${address}`,
+        search: `address=${address}&page=${page}`,
       });
     }),
     ignoreElements(),

--- a/packages/client/src/modules/ledger/store.ts
+++ b/packages/client/src/modules/ledger/store.ts
@@ -42,7 +42,7 @@ const initialState: LedgerState = {
 const ledger = createReducer<LedgerState, ActionTypes | LoadingActionTypes>(
   initialState,
 )
-  .handleAction(LoadingActions.initializeSuccess, (state, action) => ({
+  .handleAction(LoadingActions.initializeAppSuccess, (state, action) => ({
     ...initialState,
     network: action.payload.network,
     address: action.payload.address,

--- a/packages/client/src/modules/settings/actions.ts
+++ b/packages/client/src/modules/settings/actions.ts
@@ -1,4 +1,3 @@
-import { Action, Location } from "history";
 import { ILocale } from "i18n/catalog";
 import { ActionType, createStandardAction } from "typesafe-actions";
 import { SettingsState } from "./store";
@@ -11,7 +10,6 @@ import { SettingsState } from "./store";
 enum ActionTypesEnum {
   UPDATE_SETTING = "UPDATE_SETTING",
   UPDATE_SETTING_SUCCESS = "UPDATE_SETTING_SUCCESS",
-  ROUTE_CHANGE = "ROUTE_CHANGE",
 }
 
 /** ===========================================================================
@@ -27,14 +25,6 @@ const updateSettingSuccess = createStandardAction(
   ActionTypesEnum.UPDATE_SETTING_SUCCESS,
 )();
 
-interface RouteInformation extends Location {
-  action: Action;
-}
-
-const onRouteChange = createStandardAction(ActionTypesEnum.ROUTE_CHANGE)<
-  RouteInformation
->();
-
 const setLocale = (locale: ILocale) => {
   return updateSetting({ locale });
 };
@@ -47,7 +37,6 @@ const setLocale = (locale: ILocale) => {
 const actions = {
   updateSetting,
   updateSettingSuccess,
-  onRouteChange,
   setLocale,
 };
 

--- a/packages/client/src/modules/settings/store.ts
+++ b/packages/client/src/modules/settings/store.ts
@@ -5,6 +5,7 @@ import {
 } from "constants/fiat";
 import { ILocale } from "i18n/catalog";
 import { createReducer } from "typesafe-actions";
+import AppActions, { ActionTypes as AppActionTypes } from "../app/actions";
 import actions, { ActionTypes } from "./actions";
 
 /** ===========================================================================
@@ -59,16 +60,18 @@ const getInitialState = () => {
 const initialState = getInitialState();
 
 /** ===========================================================================
- * Reducer
+ * Settings Store Reducer
  * ============================================================================
  */
 
-const settings = createReducer<SettingsState, ActionTypes>(initialState)
+const settings = createReducer<SettingsState, ActionTypes | AppActionTypes>(
+  initialState,
+)
   .handleAction(actions.updateSetting, (state, action) => ({
     ...state,
     ...action.payload,
   }))
-  .handleAction(actions.onRouteChange, (state, action) => {
+  .handleAction(AppActions.onRouteChange, (state, action) => {
     /**
      * NOTE: `darkThemeEnabled` is the true theme setting, and `isDarkTheme`
      * is used to actually determine the current app theme. The reason is

--- a/packages/client/src/modules/settings/store.ts
+++ b/packages/client/src/modules/settings/store.ts
@@ -82,6 +82,7 @@ const settings = createReducer<SettingsState, ActionTypes | AppActionTypes>(
     const ON_LOGIN =
       action.payload.pathname.includes("login") ||
       window.location.pathname.includes("login");
+
     if (ON_LOGIN) {
       return {
         ...state,

--- a/packages/client/src/modules/settings/store.ts
+++ b/packages/client/src/modules/settings/store.ts
@@ -79,7 +79,10 @@ const settings = createReducer<SettingsState, ActionTypes | AppActionTypes>(
      * to light theme, but we still need to track their actual theme setting
      * in the app.
      */
-    if (action.payload.pathname.includes("login")) {
+    const ON_LOGIN =
+      action.payload.pathname.includes("login") ||
+      window.location.pathname.includes("login");
+    if (ON_LOGIN) {
       return {
         ...state,
         isDarkTheme: false,

--- a/packages/client/src/modules/transaction/epics.ts
+++ b/packages/client/src/modules/transaction/epics.ts
@@ -162,12 +162,13 @@ const syncTransactionPageEpic: EpicSignature = (action$, state$, deps) => {
     pluck("payload"),
     tap(() => {
       const { router } = deps;
-      const address = state$.value.ledger.ledger.address;
       const page = state$.value.transaction.transactionsPage;
-      router.push({
-        pathname: router.location.pathname,
-        search: `address=${address}&page=${page}`,
-      });
+      if (page > 1) {
+        router.replace({
+          pathname: router.location.pathname,
+          search: `page=${page}`,
+        });
+      }
     }),
     ignoreElements(),
   );

--- a/packages/client/src/modules/transaction/epics.ts
+++ b/packages/client/src/modules/transaction/epics.ts
@@ -161,10 +161,10 @@ const syncTransactionPageEpic: EpicSignature = (action$, state$, deps) => {
     pluck("payload"),
     tap(() => {
       const { router } = deps;
+      const address = state$.value.ledger.ledger.address;
       const page = state$.value.transaction.transactionsPage;
       router.replace({
-        search: `page=${page}`,
-        pathname: router.location.pathname,
+        search: `address=${address}&page=${page}`,
       });
     }),
     ignoreElements(),

--- a/packages/client/src/modules/transaction/epics.ts
+++ b/packages/client/src/modules/transaction/epics.ts
@@ -148,7 +148,6 @@ const pollTransactionEpic: EpicSignature = (action$, state$, deps) => {
           return Actions.transactionFailed();
         }
       } catch (err) {
-        console.log(err);
         await wait(2500);
         return Actions.pollForTransaction();
       }
@@ -163,12 +162,10 @@ const syncTransactionPageEpic: EpicSignature = (action$, state$, deps) => {
     tap(() => {
       const { router } = deps;
       const page = state$.value.transaction.transactionsPage;
-      if (page > 1) {
-        router.replace({
-          pathname: router.location.pathname,
-          search: `page=${page}`,
-        });
-      }
+      router.replace({
+        search: `page=${page}`,
+        pathname: router.location.pathname,
+      });
     }),
     ignoreElements(),
   );

--- a/packages/client/src/modules/transaction/store.ts
+++ b/packages/client/src/modules/transaction/store.ts
@@ -94,7 +94,7 @@ const transaction = createReducer<
     ...initialState,
     transactionsPage: 1,
   }))
-  .handleAction(AppActions.initializeSuccess, (state, action) => ({
+  .handleAction(AppActions.initializeAppSuccess, (state, action) => ({
     ...initialState,
     transactionsPage: action.payload.page,
   }))

--- a/packages/client/src/modules/transaction/store.ts
+++ b/packages/client/src/modules/transaction/store.ts
@@ -113,6 +113,7 @@ const transaction = createReducer<
       tx => tx.hash !== action.payload.hash,
     ),
   }))
+  .handleAction(LedgerActions.logoutSuccess, () => initialState)
   .handleAction(
     [Actions.transactionFailed, LedgerActions.closeLedgerDialog],
     state => ({

--- a/packages/client/src/pages/DashboardPage.tsx
+++ b/packages/client/src/pages/DashboardPage.tsx
@@ -371,7 +371,7 @@ const DashboardNavigationLink = ({
   localizedTitle,
 }: INavItemProps) => {
   const active = onActiveTab(pathname, title);
-  const path = `/${title.toLowerCase()}/${address}`;
+  const path = `/${title.toLowerCase()}`;
   const onClickFunction = () => runAnalyticsForTab(title);
   return (
     <Link
@@ -413,7 +413,7 @@ const getMobileDashboardNavigationLink = ({
   localizedTitle,
 }: INavItemProps & { history: History }) => {
   const active = onActiveRoute(pathname, localizedTitle);
-  const path = `/${title.toLowerCase()}/${address}`;
+  const path = `/${title.toLowerCase()}`;
   const onClickFunction = () => {
     history.push(path);
     runAnalyticsForTab(title);

--- a/packages/client/src/pages/DashboardPage.tsx
+++ b/packages/client/src/pages/DashboardPage.tsx
@@ -36,6 +36,7 @@ import { connect } from "react-redux";
 import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import styled from "styled-components";
 import {
+  CHART_TABS,
   getPortfolioTypeFromUrl,
   onActiveRoute,
   onActiveTab,
@@ -45,24 +46,15 @@ import { tFnString } from "tools/i18n-utils";
 import TransactionSwitchContainer from "transactions/TransactionSwitchContainer";
 
 /** ===========================================================================
- * Types & Config
- * ============================================================================
- */
-
-const TABS: ReadonlyArray<PORTFOLIO_CHART_TYPES> = [
-  "TOTAL",
-  "AVAILABLE",
-  "STAKING",
-  "REWARDS",
-  "COMMISSIONS",
-];
-
-/** ===========================================================================
  * React Component
  * ============================================================================
  */
 
 class DashboardPage extends React.Component<IProps> {
+  componentDidMount() {
+    this.props.setActiveChartTab(window.location.pathname.split("/")[1]);
+  }
+
   render(): JSX.Element {
     const { address, ledger, i18n, app, settings } = this.props;
     const { t, tString } = i18n;
@@ -172,7 +164,7 @@ class DashboardPage extends React.Component<IProps> {
       portfolioHistory,
     );
 
-    const AVAILABLE_TABS = TABS.filter(tab => {
+    const AVAILABLE_TABS = CHART_TABS.filter(tab => {
       if (tab === "COMMISSIONS") {
         return commissionsLinkAvailable;
       } else {
@@ -494,6 +486,7 @@ const mapStateToProps = (state: ReduxStoreState) => ({
 });
 
 const dispatchProps = {
+  setActiveChartTab: Modules.actions.app.setActiveChartTab,
   togglePortfolioSize: Modules.actions.app.togglePortfolioSize,
   toggleTransactionsSize: Modules.actions.app.toggleTransactionsSize,
 };

--- a/packages/client/src/pages/DashboardPage.tsx
+++ b/packages/client/src/pages/DashboardPage.tsx
@@ -407,12 +407,13 @@ const NavLinkContainer = styled.div`
 
 const getMobileDashboardNavigationLink = ({
   title,
+  address,
   history,
   pathname,
   localizedTitle,
 }: INavItemProps & { history: History }) => {
   const active = onActiveRoute(pathname, localizedTitle);
-  const path = localizedTitle.toLowerCase();
+  const path = `/${title.toLowerCase()}/${address}`;
   const onClickFunction = () => {
     history.push(path);
     runAnalyticsForTab(title);

--- a/packages/client/src/pages/DashboardPage.tsx
+++ b/packages/client/src/pages/DashboardPage.tsx
@@ -378,9 +378,8 @@ const DashboardNavigationLink = ({
   pathname,
   localizedTitle,
 }: INavItemProps) => {
-  const params = `?address=${address}`;
   const active = onActiveTab(pathname, title);
-  const path = `${title.toLowerCase()}${params}`;
+  const path = `/${title.toLowerCase()}/${address}`;
   const onClickFunction = () => runAnalyticsForTab(title);
   return (
     <Link

--- a/packages/client/src/test/currency-utils.test.ts
+++ b/packages/client/src/test/currency-utils.test.ts
@@ -4,11 +4,9 @@ import {
   calculateTransactionAmount,
   convertCryptoToFiat,
   denomToUnit,
-  findCurrencyFromCoinsList,
   formatCurrencyAmount,
   unitToDenom,
 } from "tools/currency-utils";
-import { coins } from "../../../utils/src/client/data/coins.json";
 import prices from "../../../utils/src/client/data/prices.json";
 
 describe("currency-utils", () => {
@@ -21,29 +19,6 @@ describe("currency-utils", () => {
 
     result = formatCurrencyAmount("1050090082.235");
     expect(result).toMatchInlineSnapshot(`"1,050,090,082.24"`);
-  });
-
-  test("findCurrencyFromCoinsList", () => {
-    let result = findCurrencyFromCoinsList("uatom", coins);
-    expect(result).toEqual({
-      id: "cosmos",
-      name: "Cosmos",
-      symbol: "atom",
-    });
-
-    result = findCurrencyFromCoinsList("1mt", coins);
-    expect(result).toEqual({
-      id: "monarch-token",
-      name: "Monarch Token",
-      symbol: "mt",
-    });
-
-    result = findCurrencyFromCoinsList("zzz-unknown-coin", coins);
-    expect(result).toEqual({
-      id: "",
-      name: "",
-      symbol: "",
-    });
   });
 
   test("denomToAtoms", () => {

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -89,7 +89,6 @@ export enum OASIS_ADDRESS_ENUM {
  * Determine if a given route link is on the current active route.
  */
 export const onActiveRoute = (pathName: string, routeName: string): boolean => {
-  console.log(pathName, routeName);
   const path = pathName.split("/")[1];
   return !!path && path.toLowerCase() === routeName.toLowerCase();
 };

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -408,6 +408,24 @@ export const onChartView = (pathname: string) => {
 };
 
 /**
+ * Valid chart tab keys.
+ */
+export const CHART_TABS: ReadonlyArray<PORTFOLIO_CHART_TYPES> = [
+  "TOTAL",
+  "AVAILABLE",
+  "STAKING",
+  "REWARDS",
+  "COMMISSIONS",
+];
+
+/**
+ *  Determine if a string is a valid chart tab key.
+ */
+export const isValidChartTab = (tab: string) => {
+  return new Set(CHART_TABS.map(x => x.toLowerCase())).has(tab);
+};
+
+/**
  * Return information on which dashboard tab the user is viewing from the
  * given url location.
  */

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -89,6 +89,7 @@ export enum OASIS_ADDRESS_ENUM {
  * Determine if a given route link is on the current active route.
  */
 export const onActiveRoute = (pathName: string, routeName: string): boolean => {
+  console.log(pathName, routeName);
   const path = pathName.split("/")[1];
   return !!path && path.toLowerCase() === routeName.toLowerCase();
 };
@@ -97,7 +98,7 @@ export const onActiveRoute = (pathName: string, routeName: string): boolean => {
  * Determine if the given tab is active given the current route.
  */
 export const onActiveTab = (pathName: string, tabName: string): boolean => {
-  const path = pathName.split("/")[2];
+  const path = pathName.split("/")[1];
   return !!path && path.toLowerCase() === tabName.toLowerCase();
 };
 
@@ -398,6 +399,13 @@ export const canRenderGraphQL = (graphqlProps: {
  */
 export const onPath = (url: string, pathString: string): boolean => {
   return url.includes(pathString);
+};
+
+/**
+ * Return true if a URL pathname is on the chart (dashboard) view.
+ */
+export const onChartView = (pathname: string) => {
+  return /total|available|staking|rewards|commissions/.test(pathname);
 };
 
 /**

--- a/packages/client/src/tools/currency-utils.ts
+++ b/packages/client/src/tools/currency-utils.ts
@@ -1,4 +1,4 @@
-import { ICoin, IQuery, NetworkDefinition } from "@anthem/utils";
+import { IQuery, NetworkDefinition } from "@anthem/utils";
 import BigNumber from "bignumber.js";
 import { trimZeroes } from "./client-utils";
 import {
@@ -48,30 +48,6 @@ export const formatCurrencyAmount = (
     const result = value.toFormat(10);
     return trimZeroes(result);
   }
-};
-
-/**
- * Find a currency from the currency list. This can be used to get the
- * coin data for the prices query.
- */
-export const findCurrencyFromCoinsList = (
-  denom: string,
-  coins: IQuery["coins"],
-): ICoin => {
-  const defaultCoin = {
-    id: "",
-    symbol: "",
-    name: "",
-  };
-
-  if (!coins) {
-    return defaultCoin;
-  }
-
-  const currencySymbol = denom.slice(1);
-  const coin = coins.find((c: ICoin) => c.symbol === currencySymbol);
-
-  return coin ? coin : defaultCoin;
 };
 
 interface CurrencyConversionMethodTypes {

--- a/packages/client/src/transactions/CeloTransactionContainer.tsx
+++ b/packages/client/src/transactions/CeloTransactionContainer.tsx
@@ -1,0 +1,91 @@
+import { GraphQLGuardComponentMultipleQueries } from "components/GraphQLGuardComponents";
+import { DashboardLoader } from "components/SharedComponents";
+import {
+  CeloTransactionsProps,
+  withCeloTransactions,
+  withGraphQLVariables,
+} from "graphql/queries";
+import Modules, { ReduxStoreState } from "modules/root";
+import { i18nSelector } from "modules/settings/selectors";
+import { DashboardError } from "pages/DashboardPage";
+import React from "react";
+import { connect } from "react-redux";
+import { RouteComponentProps } from "react-router";
+import { composeWithProps } from "tools/context-utils";
+import CeloTransactionList from "./CeloTransactionList";
+
+/** ===========================================================================
+ * React Component
+ * ============================================================================
+ */
+
+class CeloTransactionsContainer extends React.Component<IProps, {}> {
+  render(): Nullable<JSX.Element> {
+    const { i18n, transactions } = this.props;
+    const { tString } = i18n;
+    return (
+      <GraphQLGuardComponentMultipleQueries
+        tString={tString}
+        loadingComponent={<DashboardLoader />}
+        errorComponent={<DashboardError tString={tString} />}
+        results={[[transactions, "celoTransactions"]]}
+      >
+        {() => {
+          return (
+            <CeloTransactionList
+              {...this.props}
+              transactions={transactions.celoTransactions.data}
+              moreResultsExist={transactions.celoTransactions.moreResultsExist}
+            />
+          );
+        }}
+      </GraphQLGuardComponentMultipleQueries>
+    );
+  }
+}
+
+/** ===========================================================================
+ * Props
+ * ============================================================================
+ */
+
+const mapStateToProps = (state: ReduxStoreState) => ({
+  i18n: i18nSelector(state),
+  settings: Modules.selectors.settings(state),
+  ledger: Modules.selectors.ledger.ledgerSelector(state),
+  transactionsPage: Modules.selectors.transaction.transactionsPage(state),
+  extraLiveTransactions: Modules.selectors.transaction.liveTransactionsRecordSelector(
+    state,
+  ),
+});
+
+const dispatchProps = {
+  setAddress: Modules.actions.ledger.setAddress,
+  setTransactionsPage: Modules.actions.transaction.setTransactionsPage,
+  removeLocalCopyOfTransaction:
+    Modules.actions.transaction.removeLocalCopyOfTransaction,
+};
+
+const withProps = connect(mapStateToProps, dispatchProps);
+
+interface ComponentProps {}
+
+type ConnectProps = ReturnType<typeof mapStateToProps> & typeof dispatchProps;
+
+export type TransactionListProps = ConnectProps & RouteComponentProps;
+
+interface IProps
+  extends TransactionListProps,
+    CeloTransactionsProps,
+    ComponentProps {}
+
+/** ===========================================================================
+ * Export
+ * ============================================================================
+ */
+
+export default composeWithProps<ComponentProps>(
+  withProps,
+  withGraphQLVariables,
+  withCeloTransactions,
+)(CeloTransactionsContainer);

--- a/packages/client/src/transactions/CeloTransactionList.tsx
+++ b/packages/client/src/transactions/CeloTransactionList.tsx
@@ -23,6 +23,9 @@ class CeloTransactionList extends React.PureComponent<IProps> {
 
     const TXS_EXIST = transactions.length > 0;
 
+    console.log("CELO transaction:");
+    console.log(transactions);
+
     return (
       <React.Fragment>
         {TXS_EXIST ? (

--- a/packages/client/src/transactions/CeloTransactionList.tsx
+++ b/packages/client/src/transactions/CeloTransactionList.tsx
@@ -1,0 +1,107 @@
+import { ICeloTransaction } from "@anthem/utils";
+import { H5 } from "@blueprintjs/core";
+import { Centered } from "components/SharedComponents";
+import Toast from "components/Toast";
+import React from "react";
+import { TransactionListProps } from "./CeloTransactionContainer";
+import CeloTransactionListItem from "./CeloTransactionListItem";
+// import { TransactionPaginationControls } from "./TransactionComponents";
+
+/** ===========================================================================
+ * React Component
+ * ============================================================================
+ */
+
+class CeloTransactionList extends React.PureComponent<IProps> {
+  render(): JSX.Element {
+    const {
+      // isDetailView,
+      transactions,
+      // transactionsPage,
+      // moreResultsExist,
+    } = this.props;
+
+    const TXS_EXIST = transactions.length > 0;
+
+    return (
+      <React.Fragment>
+        {TXS_EXIST ? (
+          transactions.map(this.renderTransactionItem)
+        ) : (
+          <Centered>
+            <H5>No transactions exist</H5>
+          </Centered>
+        )}
+        {/* {!isDetailView && TXS_EXIST && (
+          <TransactionPaginationControls
+            firstTxDate={transactions[0].date}
+            lastTxDate={transactions[transactions.length - 1].date}
+            back={this.pageBack}
+            forward={this.pageForward}
+            page={transactionsPage}
+            moreResultsExist={!!moreResultsExist}
+          />
+        )} */}
+      </React.Fragment>
+    );
+  }
+
+  pageBack = () => {
+    this.props.setTransactionsPage(this.props.transactionsPage - 1);
+  };
+
+  pageForward = () => {
+    this.props.setTransactionsPage(this.props.transactionsPage + 1);
+  };
+
+  renderTransactionItem = (transaction: ICeloTransaction) => {
+    const { ledger, settings, i18n, isDetailView, setAddress } = this.props;
+    const { network, address } = ledger;
+    const { t, tString, locale } = i18n;
+    const { isDesktop, fiatCurrency } = settings;
+    return (
+      <CeloTransactionListItem
+        t={t}
+        locale={locale}
+        tString={tString}
+        address={address}
+        network={network}
+        isDesktop={isDesktop}
+        key={transaction.hash}
+        setAddress={setAddress}
+        transaction={transaction}
+        fiatCurrency={fiatCurrency}
+        isDetailView={isDetailView}
+        onCopySuccess={this.onCopySuccess}
+      />
+    );
+  };
+
+  onCopySuccess = (address: string) => {
+    Toast.success(
+      this.props.i18n.tString("Address {{address}} copied to clipboard", {
+        address,
+      }),
+    );
+  };
+}
+
+/** ===========================================================================
+ * Props
+ * ============================================================================
+ */
+
+interface ComponentProps extends TransactionListProps {
+  isDetailView?: boolean;
+  moreResultsExist?: boolean;
+  transactions: ICeloTransaction[];
+}
+
+type IProps = ComponentProps;
+
+/** ===========================================================================
+ * Export
+ * ============================================================================
+ */
+
+export default CeloTransactionList;

--- a/packages/client/src/transactions/CeloTransactionListItem.tsx
+++ b/packages/client/src/transactions/CeloTransactionListItem.tsx
@@ -1,0 +1,45 @@
+import { ICeloTransaction, NetworkDefinition } from "@anthem/utils";
+import { Card, Elevation } from "@blueprintjs/core";
+import { FiatCurrency } from "constants/fiat";
+import { ILocale } from "i18n/catalog";
+import Modules from "modules/root";
+import React from "react";
+import { TranslateMethodProps } from "tools/i18n-utils";
+import { TransactionCardStyles } from "./TransactionComponents";
+
+/** ===========================================================================
+ * Types & Config
+ * ============================================================================
+ */
+
+interface IProps extends TranslateMethodProps {
+  isDetailView?: boolean;
+  transaction: ICeloTransaction;
+  address: string;
+  locale: ILocale;
+  isDesktop: boolean;
+  fiatCurrency: FiatCurrency;
+  network: NetworkDefinition;
+  setAddress: typeof Modules.actions.ledger.setAddress;
+  onCopySuccess: (address: string) => void;
+}
+
+/** ===========================================================================
+ * React Component
+ * ============================================================================
+ */
+
+class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
+  render(): Nullable<JSX.Element> {
+    return (
+      <Card style={TransactionCardStyles} elevation={Elevation.TWO}></Card>
+    );
+  }
+}
+
+/** ===========================================================================
+ * Export
+ * ============================================================================
+ */
+
+export default CeloTransactionListItem;

--- a/packages/client/src/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/transactions/CosmosTransactionListItem.tsx
@@ -21,7 +21,6 @@ import { ILocale } from "i18n/catalog";
 import Modules from "modules/root";
 import React from "react";
 import { Link } from "react-router-dom";
-import styled from "styled-components";
 import {
   copyTextToClipboard,
   justFormatChainString,

--- a/packages/client/src/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/transactions/CosmosTransactionListItem.tsx
@@ -20,6 +20,7 @@ import { FiatCurrency } from "constants/fiat";
 import { ILocale } from "i18n/catalog";
 import Modules from "modules/root";
 import React from "react";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 import {
   copyTextToClipboard,
@@ -51,6 +52,7 @@ import {
   EventRow,
   EventRowBottom,
   EventRowItem,
+  EventText,
   TransactionCardStyles,
   TransactionFailedStatusBar,
   TransactionLinkText,
@@ -340,7 +342,9 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   };
 
   renderTransactionHashLink = (hash: string, chain: string) => {
-    const TxHashLink = (
+    // If viewing in the transaction list view, render a link to the detail
+    // view. Otherwise just render a link to copy the hash.
+    const TxHashLink = this.props.isDetailView ? (
       <ClickableEventRow onClick={() => copyTextToClipboard(hash)}>
         <EventIconBox>
           <LinkIcon />
@@ -350,11 +354,25 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
           <TransactionLinkText>{hash.slice(0, 15)}...</TransactionLinkText>
         </EventContextBox>
       </ClickableEventRow>
+    ) : (
+      <Link to={`/txs/${hash}`}>
+        <ClickableEventRow onClick={() => null}>
+          <EventIconBox>
+            <LinkIcon />
+          </EventIconBox>
+          <EventContextBox>
+            <EventText style={{ fontWeight: "bold" }}>
+              Transaction Hash
+            </EventText>
+            <TransactionLinkText>{hash.slice(0, 15)}...</TransactionLinkText>
+          </EventContextBox>
+        </ClickableEventRow>
+      </Link>
     );
 
     return (
       <React.Fragment>
-        {this.props.isDesktop ? (
+        {this.props.isDetailView && this.props.isDesktop ? (
           <Tooltip position={Position.TOP} content="Click to copy hash">
             {TxHashLink}
           </Tooltip>
@@ -487,11 +505,6 @@ export const getCosmosTransactionLabelFromType = (
       return assertUnreachable(transactionType);
   }
 };
-
-const EventText = styled.p`
-  margin: 0;
-  padding: 0;
-`;
 
 /** ===========================================================================
  * Export

--- a/packages/client/src/transactions/TransactionSwitchContainer.tsx
+++ b/packages/client/src/transactions/TransactionSwitchContainer.tsx
@@ -11,8 +11,9 @@ import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps } from "react-router";
 import { composeWithProps } from "tools/context-utils";
+import CeloTransactionContainer from "transactions/CeloTransactionContainer";
 import CosmosTransactionContainer from "transactions/CosmosTransactionContainer";
-import OasisTransactionsContainer from "transactions/OasisTransactionContainer";
+import OasisTransactionContainer from "transactions/OasisTransactionContainer";
 
 /** ===========================================================================
  * Types & Config
@@ -80,7 +81,9 @@ class TransactionSwitchContainer extends React.Component<IProps, IState> {
       case "COSMOS":
         return <CosmosTransactionContainer />;
       case "OASIS":
-        return <OasisTransactionsContainer />;
+        return <OasisTransactionContainer />;
+      case "CELO":
+        return <CeloTransactionContainer />;
       default:
         return null;
     }

--- a/packages/cypress/src/integration/navigation.spec.ts
+++ b/packages/cypress/src/integration/navigation.spec.ts
@@ -23,11 +23,11 @@ SCREEN_SIZES.forEach(({ type, size }) => {
      * Redirect to login.
      */
     it("Other routes redirect to /login if no address is set", () => {
-      cy.visit(`${APP_URL}/dashboard`);
+      cy.visit(`${APP_URL}`);
       UTILS.shouldMatchText("login-page-title", "Earn Rewards on Cryptoassets");
       cy.url().should("contain", "/login");
 
-      cy.visit(`${APP_URL}/dashboard/available`);
+      cy.visit(`${APP_URL}/available`);
       UTILS.shouldMatchText("login-page-title", "Earn Rewards on Cryptoassets");
       cy.url().should("contain", "/login");
 
@@ -52,23 +52,18 @@ SCREEN_SIZES.forEach(({ type, size }) => {
      */
     it("All navigation sub-routes in the Dashboard can be visited", () => {
       if (type.isDesktop()) {
-        cy.visit(`${APP_URL}/dashboard/available`);
-        cy.contains("AVAILABLE");
-        cy.contains("REWARDS");
+        cy.visit(`${APP_URL}/total`);
+        cy.url().should("contain", "/total");
 
-        cy.visit(`${APP_URL}/dashboard/rewards`);
-        cy.contains("AVAILABLE");
-        cy.contains("REWARDS");
+        cy.visit(`${APP_URL}/available`);
+        cy.url().should("contain", "/available");
+
+        cy.visit(`${APP_URL}/rewards`);
+        cy.url().should("contain", "/rewards");
+
+        cy.visit(`${APP_URL}/staking`);
+        cy.url().should("contain", "/staking");
       }
-
-      // cy.visit(`${APP_URL}/dashboard/total`);
-      // cy.contains("Dashboard");
-
-      // cy.visit(`${APP_URL}/dashboard/staking`);
-      // cy.contains("Dashboard");
-
-      // cy.visit(`${APP_URL}/dashboard/unbonding`);
-      // cy.contains("Dashboard");
     });
 
     /**
@@ -90,15 +85,6 @@ SCREEN_SIZES.forEach(({ type, size }) => {
 
       UTILS.findAndClick("rewards-navigation-link");
       cy.url().should("contain", "/rewards");
-
-      // UTILS.findAndClick("total-navigation-link");
-      // cy.url().should("contain", "/total");
-
-      // UTILS.findAndClick("staking-navigation-link");
-      // cy.url().should("contain", "/staking");
-
-      // UTILS.findAndClick("pending-navigation-link");
-      // cy.url().should("contain", "/pending");
     });
 
     /**

--- a/packages/cypress/src/support/cypress-utils.ts
+++ b/packages/cypress/src/support/cypress-utils.ts
@@ -92,7 +92,7 @@ const loginWithAddress = (type: any, useLedger = false) => {
    * Visit the app. Expect redirect to login and initiate the login
    * enter address flow.
    */
-  cy.visit(`${APP_URL}/dashboard`);
+  cy.visit(`${APP_URL}/total`);
   cy.url().should("contain", "/login");
 
   /**
@@ -122,7 +122,7 @@ const loginWithAddress = (type: any, useLedger = false) => {
     );
   }
 
-  cy.url().should("contain", "/dashboard/total");
+  cy.url().should("contain", "/total");
 };
 
 /**

--- a/packages/server/src/schema/schema.graphql
+++ b/packages/server/src/schema/schema.graphql
@@ -28,7 +28,6 @@ type Query {
 
   # CoinGecko Price APIs
   prices(currency: String!, versus: String!): Price!
-  coins: [Coin!]
 
   fiatCurrencies: [FiatCurrency!]!
 
@@ -665,17 +664,8 @@ type DistributionParameters {
   community_tax: String!
 }
 
-# *****************************************************************************
-# CoinGecko Price APIs
-
 type Price {
   price: Float!
-}
-
-type Coin {
-  id: String!
-  symbol: String!
-  name: String!
 }
 
 type FiatCurrency {

--- a/packages/server/src/schema/schema.graphql
+++ b/packages/server/src/schema/schema.graphql
@@ -102,10 +102,39 @@ type CeloTransactionResult {
   moreResultsExist: Boolean!
 }
 
-# TODO: Complete the transaction/events types for Celo Network
 type CeloTransaction {
-  date: String!
-  height: Int!
+  blockNumber: Int!
+  hash: String!
+  from: String!
+  to: String!
+  details: CeloTransactionDetails!
+  tags: [CeloTransactionTags!]!
+}
+
+type CeloTransactionTags {
+  tag: String!
+  parameters: CeloTransactionTagParameter!
+}
+
+type CeloTransactionTagParameter {
+  account: String!
+  proposalId: String!
+}
+
+type CeloTransactionDetails {
+  nonce: String!
+  gasPrice: String!
+  gas: String!
+  feeCurrency: String!
+  gatewayFeeRecipient: String!
+  gatewayFee: String!
+  to: String!
+  value: String!
+  input: String!
+  v: String!
+  r: String!
+  s: String!
+  hash: String!
 }
 
 # *****************************************************************************

--- a/packages/server/src/schema/schema.graphql
+++ b/packages/server/src/schema/schema.graphql
@@ -66,7 +66,7 @@ type CeloAccountBalancesType {
 type CeloAccountBalances {
   address: String!
   height: String!
-  goldTokenBalance: String!
+  availableGoldBalance: String!
   totalLockedGoldBalance: String!
   nonVotingLockedGoldBalance: String!
   votingLockedGoldBalance: String!
@@ -87,7 +87,7 @@ type CeloAccountSnapshot {
   address: String!
   height: String!
   snapshotReward: String!
-  goldTokenBalance: String!
+  availableGoldBalance: String!
   totalLockedGoldBalance: String!
   nonVotingLockedGoldBalance: String!
   votingLockedGoldBalance: String!

--- a/packages/server/src/server/axios-utils.ts
+++ b/packages/server/src/server/axios-utils.ts
@@ -1,6 +1,7 @@
 import { assertUnreachable, NETWORK_NAME } from "@anthem/utils";
 import axios from "axios";
 import moment from "moment";
+import ENV from "src/tools/server-env";
 import { logger } from "../tools/server-utils";
 
 /** ===========================================================================
@@ -8,25 +9,15 @@ import { logger } from "../tools/server-utils";
  * ============================================================================
  */
 
-// 49.12.81.53:10100 - Oasis
-// 49.12.81.53:10101 - Celo
-
-const COSMOS_LCD = "https://cosmos-lcd.chorus.one:1317";
-const TERRA_LCD = "https://terra-lcd.chorus.one:1317";
-const KAVA_LCD = "https://kava-lcd.chorus.one:1317";
-const COSMOS_API = "https://stargate.cosmos.network";
 const CRYPTO_COMPARE = "https://min-api.cryptocompare.com";
-const OASIS = "http://216.18.206.50:10100";
-const CELO = "http://158.85.63.136";
 
 const HOSTS = {
-  COSMOS_LCD,
-  TERRA_LCD,
-  KAVA_LCD,
   CRYPTO_COMPARE,
-  COSMOS_API,
-  OASIS,
-  CELO,
+  CELO: ENV.CELO_EXTRACTOR_API,
+  OASIS: ENV.OASIS_EXTRACTOR_API,
+  KAVA_LCD: ENV.KAVA_LCD_NODE,
+  TERRA_LCD: ENV.TERRA_LCD_NODE,
+  COSMOS_LCD: ENV.COSMOS_LCD_NODE,
 };
 
 const hostsList = Object.values(HOSTS);

--- a/packages/server/src/server/axios-utils.ts
+++ b/packages/server/src/server/axios-utils.ts
@@ -1,7 +1,7 @@
 import { assertUnreachable, NETWORK_NAME } from "@anthem/utils";
 import axios from "axios";
 import moment from "moment";
-import ENV from "src/tools/server-env";
+import ENV from "../tools/server-env";
 import { logger } from "../tools/server-utils";
 
 /** ===========================================================================

--- a/packages/server/src/server/axios-utils.ts
+++ b/packages/server/src/server/axios-utils.ts
@@ -12,7 +12,6 @@ const COSMOS_LCD = "https://cosmos-lcd.chorus.one:1317";
 const TERRA_LCD = "https://terra-lcd.chorus.one:1317";
 const KAVA_LCD = "https://kava-lcd.chorus.one:1317";
 const COSMOS_API = "https://stargate.cosmos.network";
-const COIN_GECKO_API = "https://api.coingecko.com/api/v3";
 const CRYPTO_COMPARE = "https://min-api.cryptocompare.com";
 const OASIS = "http://216.18.206.50:10100";
 const CELO = "http://158.85.63.136";
@@ -23,7 +22,6 @@ const HOSTS = {
   KAVA_LCD,
   CRYPTO_COMPARE,
   COSMOS_API,
-  COIN_GECKO_API,
   OASIS,
   CELO,
 };

--- a/packages/server/src/server/axios-utils.ts
+++ b/packages/server/src/server/axios-utils.ts
@@ -8,6 +8,9 @@ import { logger } from "../tools/server-utils";
  * ============================================================================
  */
 
+// 49.12.81.53:10100 - Oasis
+// 49.12.81.53:10101 - Celo
+
 const COSMOS_LCD = "https://cosmos-lcd.chorus.one:1317";
 const TERRA_LCD = "https://terra-lcd.chorus.one:1317";
 const KAVA_LCD = "https://kava-lcd.chorus.one:1317";

--- a/packages/server/src/server/resolvers.ts
+++ b/packages/server/src/server/resolvers.ts
@@ -7,7 +7,6 @@ import {
   IAccountInformationQueryVariables,
   ICeloAccountHistoryQueryVariables,
   ICeloTransactionsQueryVariables,
-  ICoinsQueryVariables,
   ICosmosAccountBalancesType,
   ICosmosTransactionsQueryVariables,
   IDailyPercentChangeQueryVariables,
@@ -332,13 +331,6 @@ const resolvers = {
       }
 
       return EXCHANGE_DATA_API.fetchExchangeRate(currency, versus);
-    },
-
-    coins: async (
-      _: void,
-      args: ICoinsQueryVariables,
-    ): Promise<IQuery["coins"]> => {
-      return EXCHANGE_DATA_API.fetchCoinsList();
     },
 
     fiatPriceHistory: async (

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -50,8 +50,6 @@ const fetchAccountBalances = async (
   const host = getHostFromNetworkName(network.name);
   const url = `${host}/accounts/${address}/balances`;
   const response = await AxiosUtil.get<ICeloAccountBalances>(url);
-  console.log(url);
-
   return { celo: response };
 };
 
@@ -63,9 +61,8 @@ const fetchAccountHistory = async (
   network: NetworkDefinition,
 ): Promise<IQuery["celoAccountHistory"]> => {
   const host = getHostFromNetworkName(network.name);
-  const response = await AxiosUtil.get<CeloAccountSnapshot[]>(
-    `${host}/accounts/${address}/history`,
-  );
+  const url = `${host}/accounts/${address}/history`;
+  const response = await AxiosUtil.get<CeloAccountSnapshot[]>(url);
 
   return response;
 };
@@ -81,10 +78,9 @@ const fetchTransactions = async (
 ): Promise<IQuery["celoTransactions"]> => {
   const host = getHostFromNetworkName(network.name);
 
-  // TODO: Implement
-  // const response = await AxiosUtil.get<any[]>(
-  //   `${host}/account/${address}/events`,
-  // );
+  // TODO: Update to use response type
+  // const url = `${host}/accounts/${address}/transactions`;
+  // const response = await AxiosUtil.get<any[]>(url);
 
   return {
     page: 1,

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -1,6 +1,9 @@
 import {
   ICeloAccountBalances,
   ICeloAccountBalancesType,
+  ICeloTransaction,
+  ICeloTransactionDetails,
+  ICeloTransactionTags,
   IDelegation,
   IQuery,
   NetworkDefinition,
@@ -31,6 +34,18 @@ interface CeloAccountSnapshot {
   pendingWithdrawalBalance: string;
   celoUSDValue: string;
   delegations: CeloDelegation[];
+}
+
+interface CeloTransactionResponse {
+  blockNumber: number;
+  hash: string;
+  from: string;
+  to: string;
+  tags: ICeloTransactionTags[];
+  logs: any; // Not used yet
+  details: {
+    transaction: ICeloTransactionDetails;
+  };
 }
 
 /** ===========================================================================
@@ -78,15 +93,19 @@ const fetchTransactions = async (
 ): Promise<IQuery["celoTransactions"]> => {
   const host = getHostFromNetworkName(network.name);
 
-  // TODO: Update to use response type
-  // const url = `${host}/accounts/${address}/transactions`;
-  // const response = await AxiosUtil.get<any[]>(url);
+  const url = `${host}/accounts/${address}/transactions`;
+  const response = await AxiosUtil.get<CeloTransactionResponse[]>(url);
+
+  const formattedResponse: ICeloTransaction[] = response.map(x => ({
+    ...x,
+    details: x.details.transaction,
+  }));
 
   return {
     page: 1,
     limit: 25,
     moreResultsExist: false,
-    data: [],
+    data: formattedResponse,
   };
 };
 

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -49,7 +49,7 @@ const fetchAccountBalances = async (
 ): Promise<ICeloAccountBalancesType> => {
   const host = getHostFromNetworkName(network.name);
   const response = await AxiosUtil.get<ICeloAccountBalances>(
-    `${host}/account/${address}`,
+    `${host}/accounts/${address}/balances`,
   );
 
   return { celo: response };
@@ -64,7 +64,7 @@ const fetchAccountHistory = async (
 ): Promise<IQuery["celoAccountHistory"]> => {
   const host = getHostFromNetworkName(network.name);
   const response = await AxiosUtil.get<CeloAccountSnapshot[]>(
-    `${host}/history/${address}`,
+    `${host}/accounts/${address}/history`,
   );
 
   return response;

--- a/packages/server/src/server/sources/celo.ts
+++ b/packages/server/src/server/sources/celo.ts
@@ -24,7 +24,7 @@ interface CeloAccountSnapshot {
   address: string;
   height: string;
   snapshotReward: string;
-  goldTokenBalance: string;
+  availableGoldBalance: string;
   totalLockedGoldBalance: string;
   nonVotingLockedGoldBalance: string;
   votingLockedGoldBalance: string;
@@ -48,9 +48,9 @@ const fetchAccountBalances = async (
   network: NetworkDefinition,
 ): Promise<ICeloAccountBalancesType> => {
   const host = getHostFromNetworkName(network.name);
-  const response = await AxiosUtil.get<ICeloAccountBalances>(
-    `${host}/accounts/${address}/balances`,
-  );
+  const url = `${host}/accounts/${address}/balances`;
+  const response = await AxiosUtil.get<ICeloAccountBalances>(url);
+  console.log(url);
 
   return { celo: response };
 };

--- a/packages/server/src/server/sources/cosmos-extractor.ts
+++ b/packages/server/src/server/sources/cosmos-extractor.ts
@@ -14,6 +14,7 @@ import ENV from "../../tools/server-env";
 import {
   filterSanityCheckHeights,
   formatTransactionResponse,
+  gatherEndOfDayBalanceValues,
   mapSumToBalance,
 } from "../../tools/server-utils";
 import { getSqlQueryString, SQLVariables } from "../../tools/sql-utils";
@@ -156,7 +157,8 @@ const getPortfolioBalanceHistory = async (request: {
   const variables = { address };
   const balanceQuery = getBalanceQueryForAddress();
   const query = balanceQuery(variables);
-  return queryPostgresCosmosSdkPool(network.name, query);
+  const response = await queryPostgresCosmosSdkPool(network.name, query);
+  return gatherEndOfDayBalanceValues(response);
 };
 
 const getPortfolioDelegatorRewards = async (request: {

--- a/packages/server/src/server/sources/exchange-data.ts
+++ b/packages/server/src/server/sources/exchange-data.ts
@@ -151,9 +151,7 @@ const fetchExchangeRate = async (
   const versus = versusId.toUpperCase();
   const currency = currencyId.toUpperCase();
 
-  // const url = `${HOSTS.COIN_GECKO_API}/simple/price?ids=${currency}&vs_currencies=${versus}`;
   const url = `${HOSTS.CRYPTO_COMPARE}/data/price?fsym=${currency}&tsyms=${versus}`;
-  console.log(url);
 
   // The API may fail from time to time, add a retry allowance:
   const result = await AxiosUtil.get(url, 2);

--- a/packages/server/src/server/sources/exchange-data.ts
+++ b/packages/server/src/server/sources/exchange-data.ts
@@ -71,6 +71,7 @@ const fetchDailyPercentChangeInPrice = async (
   const to = fiat.toUpperCase();
 
   const url = `${HOSTS.CRYPTO_COMPARE}/data/v2/histohour?fsym=${from}&tsym=${to}&limit=24&api_key=${ENV.CRYPTO_COMPARE_API_KEY}`;
+  console.log(url);
 
   // Fetch the price change
   const result = await AxiosUtil.get(url);

--- a/packages/server/src/server/sources/exchange-data.ts
+++ b/packages/server/src/server/sources/exchange-data.ts
@@ -148,16 +148,18 @@ const fetchExchangeRate = async (
   currencyId: string,
   versusId: string,
 ): Promise<IQuery["prices"]> => {
-  const versus = versusId.toLowerCase();
-  const currency = currencyId.toLowerCase();
+  const versus = versusId.toUpperCase();
+  const currency = currencyId.toUpperCase();
 
-  const url = `${HOSTS.COIN_GECKO_API}/simple/price?ids=${currency}&vs_currencies=${versus}`;
+  // const url = `${HOSTS.COIN_GECKO_API}/simple/price?ids=${currency}&vs_currencies=${versus}`;
+  const url = `${HOSTS.CRYPTO_COMPARE}/data/price?fsym=${currency}&tsyms=${versus}`;
+  console.log(url);
 
   // The API may fail from time to time, add a retry allowance:
   const result = await AxiosUtil.get(url, 2);
 
   return {
-    price: result[currency][versus],
+    price: result[versus],
   };
 };
 

--- a/packages/server/src/server/sources/exchange-data.ts
+++ b/packages/server/src/server/sources/exchange-data.ts
@@ -161,13 +161,6 @@ const fetchExchangeRate = async (
   };
 };
 
-/**
- * Fetch coins list data.
- */
-const fetchCoinsList = async (): Promise<IQuery["coins"]> => {
-  return AxiosUtil.get(`${HOSTS.COIN_GECKO_API}/coins/list`);
-};
-
 /** ===========================================================================
  * Export
  * ============================================================================
@@ -176,7 +169,6 @@ const fetchCoinsList = async (): Promise<IQuery["coins"]> => {
 const EXCHANGE_DATA_API = {
   fetchDailyPercentChangeInPrice,
   fetchPortfolioFiatPriceHistory,
-  fetchCoinsList,
   fetchExchangeRate,
 };
 

--- a/packages/server/src/server/sources/exchange-data.ts
+++ b/packages/server/src/server/sources/exchange-data.ts
@@ -71,7 +71,6 @@ const fetchDailyPercentChangeInPrice = async (
   const to = fiat.toUpperCase();
 
   const url = `${HOSTS.CRYPTO_COMPARE}/data/v2/histohour?fsym=${from}&tsym=${to}&limit=24&api_key=${ENV.CRYPTO_COMPARE_API_KEY}`;
-  console.log(url);
 
   // Fetch the price change
   const result = await AxiosUtil.get(url);

--- a/packages/server/src/server/sources/oasis.ts
+++ b/packages/server/src/server/sources/oasis.ts
@@ -241,6 +241,21 @@ const fetchAccountBalances = async (
   return { oasis: balances };
 };
 
+/**
+ * Fetch account history.
+ *
+ * TODO: Update this and add GraphQL types/resolvers.
+ */
+const fetchAccountHistory = async (
+  address: string,
+  network: NetworkDefinition,
+): Promise<any> => {
+  const host = getHostFromNetworkName(network.name);
+  const url = `${host}/accounts/${address}/history`;
+  const response = await AxiosUtil.get<any>(url);
+  return response;
+};
+
 const fetchTransactions = async (
   address: string,
   pageSize: number,
@@ -470,6 +485,7 @@ const MOCK_OASIS_EVENTS: OasisTransaction[] = [
 
 const OASIS = {
   fetchAccountBalances,
+  fetchAccountHistory,
   fetchTransactions,
 };
 

--- a/packages/server/src/tools/server-env.ts
+++ b/packages/server/src/tools/server-env.ts
@@ -29,6 +29,14 @@ const RECORD_CLIENT_DATA = getenv.bool("RECORD_CLIENT_DATA", false);
 const SENTRY_DSN = getenv.string("SENTRY_DSN", "");
 const CRYPTO_COMPARE_API_KEY = getenv.string("CRYPTO_COMPARE_API_KEY");
 
+// External APIs
+const KAVA_LCD_NODE = getenv.string("KAVA_LCD_NODE");
+const TERRA_LCD_NODE = getenv.string("TERRA_LCD_NODE");
+const COSMOS_LCD_NODE = getenv.string("COSMOS_LCD_NODE");
+const CELO_EXTRACTOR_API = getenv.string("CELO_EXTRACTOR_API");
+const OASIS_EXTRACTOR_API = getenv.string("OASIS_EXTRACTOR_API");
+
+// Database names
 const COSMOS_DB = getenv.string("COSMOS_DB", "cosmos4");
 const TERRA_DB = getenv.string("TERRA_DB", "terra");
 const KAVA_DB = getenv.string("KAVA_DB", "kava");
@@ -50,6 +58,11 @@ const ENV = {
   COSMOS_DB,
   TERRA_DB,
   KAVA_DB,
+  KAVA_LCD_NODE,
+  TERRA_LCD_NODE,
+  COSMOS_LCD_NODE,
+  CELO_EXTRACTOR_API,
+  OASIS_EXTRACTOR_API,
 };
 
 /** ===========================================================================

--- a/packages/server/src/tools/server-utils.ts
+++ b/packages/server/src/tools/server-utils.ts
@@ -1,4 +1,10 @@
-import { IMsgDelegate, ITransaction, ITxMsg } from "@anthem/utils";
+import {
+  IBalance,
+  IMsgDelegate,
+  IPortfolioBalance,
+  ITransaction,
+  ITxMsg,
+} from "@anthem/utils";
 import * as Sentry from "@sentry/node";
 import chalk from "chalk";
 import { NextFunction, Request, Response } from "express";
@@ -137,6 +143,35 @@ export const hasKeys = (obj: any, keys: ReadonlyArray<string>): boolean => {
     }
   }
   return true;
+};
+
+const DATE_FORMAT = "MMM DD, YYYY";
+
+/**
+ * Get a date key based on the month/day/year.
+ */
+export const toDateKey = (date: string) => {
+  return moment(date).format(DATE_FORMAT);
+};
+
+/**
+ * Transform balances response capturing only the end of day values.
+ */
+export const gatherEndOfDayBalanceValues = (balances: IPortfolioBalance[]) => {
+  const result: IPortfolioBalance[] = [];
+  const dates = new Set<string>();
+
+  for (let i = balances.length - 1; i > 0; i--) {
+    const x = balances[i];
+    const key = toDateKey(x.timestamp);
+    if (!dates.has(key)) {
+      result.push(x);
+      dates.add(key);
+    }
+  }
+
+  const endOfDayValues = result.reverse();
+  return endOfDayValues;
 };
 
 /**

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --watch",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test": "yarn lint && yarn test:unit",
-    "build:types": "graphql-build --outputFile=./src/schema",
+    "build:types": "graphql-build --outputFile=./src/schema && yarn gql",
     "gql": "yarn gqlgen && chmod +x scripts/gql.sh && scripts/gql.sh",
     "gqlgen": "gql-lib --schemaFilePath ../server/src/schema/schema.graphql --destDirPath ./src/client/gql --depthLimit 10",
     "record": "yarn gql && yarn mocks:refresh && yarn mocks:generate && yarn format",

--- a/packages/utils/src/client/gql/queries/accountBalances.gql
+++ b/packages/utils/src/client/gql/queries/accountBalances.gql
@@ -35,7 +35,7 @@ query accountBalances($address: String!){
             celo{
                 address
                 height
-                goldTokenBalance
+                availableGoldBalance
                 totalLockedGoldBalance
                 nonVotingLockedGoldBalance
                 votingLockedGoldBalance

--- a/packages/utils/src/client/gql/queries/celoAccountHistory.gql
+++ b/packages/utils/src/client/gql/queries/celoAccountHistory.gql
@@ -4,7 +4,7 @@ query celoAccountHistory($address: String!, $fiat: String!){
         address
         height
         snapshotReward
-        goldTokenBalance
+        availableGoldBalance
         totalLockedGoldBalance
         nonVotingLockedGoldBalance
         votingLockedGoldBalance

--- a/packages/utils/src/client/gql/queries/celoTransactions.gql
+++ b/packages/utils/src/client/gql/queries/celoTransactions.gql
@@ -3,8 +3,32 @@ query celoTransactions($address: String!, $startingPage: Float, $pageSize: Float
         page
         limit
         data{
-            date
-            height
+            blockNumber
+            hash
+            from
+            to
+            details{
+                nonce
+                gasPrice
+                gas
+                feeCurrency
+                gatewayFeeRecipient
+                gatewayFee
+                to
+                value
+                input
+                v
+                r
+                s
+                hash
+            }
+            tags{
+                tag
+                parameters{
+                    account
+                    proposalId
+                }
+            }
         }
         moreResultsExist
     }

--- a/packages/utils/src/client/gql/queries/coins.gql
+++ b/packages/utils/src/client/gql/queries/coins.gql
@@ -1,7 +1,0 @@
-query coins{
-    coins{
-        id
-        symbol
-        name
-    }
-}

--- a/packages/utils/src/client/gql/queries/oasisTransactions.gql
+++ b/packages/utils/src/client/gql/queries/oasisTransactions.gql
@@ -3,7 +3,7 @@ query oasisTransactions($address: String!, $startingPage: Float, $pageSize: Floa
         page
         limit
         data{
-            amount
+            fee
             gas
             gas_price
             height
@@ -24,20 +24,19 @@ query oasisTransactions($address: String!, $startingPage: Float, $pageSize: Floa
                 }
                 ... on OasisEscrowAddEvent {
                     type
-                    owner
-                    escrow
+                    to
                     tokens
                 }
                 ... on OasisEscrowTakeEvent {
                     type
-                    owner
+                    from
+                    to
                     tokens
                 }
                 ... on OasisEscrowReclaimEvent {
                     type
-                    owner
-                    escrow
-                    tokens
+                    from
+                    shares
                 }
                 ... on OasisRegisterEntityEvent {
                     type

--- a/packages/utils/src/graphql/types.tsx
+++ b/packages/utils/src/graphql/types.tsx
@@ -82,7 +82,7 @@ export interface ICeloAccountBalances {
    __typename?: "CeloAccountBalances";
   address: Scalars["String"];
   height: Scalars["String"];
-  goldTokenBalance: Scalars["String"];
+  availableGoldBalance: Scalars["String"];
   totalLockedGoldBalance: Scalars["String"];
   nonVotingLockedGoldBalance: Scalars["String"];
   votingLockedGoldBalance: Scalars["String"];
@@ -102,7 +102,7 @@ export interface ICeloAccountSnapshot {
   address: Scalars["String"];
   height: Scalars["String"];
   snapshotReward: Scalars["String"];
-  goldTokenBalance: Scalars["String"];
+  availableGoldBalance: Scalars["String"];
   totalLockedGoldBalance: Scalars["String"];
   nonVotingLockedGoldBalance: Scalars["String"];
   votingLockedGoldBalance: Scalars["String"];
@@ -864,7 +864,7 @@ export type IAccountBalancesQuery = (
     { __typename?: "CeloAccountBalancesType" }
     & { celo: (
       { __typename?: "CeloAccountBalances" }
-      & Pick<ICeloAccountBalances, "address" | "height" | "goldTokenBalance" | "totalLockedGoldBalance" | "nonVotingLockedGoldBalance" | "votingLockedGoldBalance" | "pendingWithdrawalBalance" | "celoUSDValue">
+      & Pick<ICeloAccountBalances, "address" | "height" | "availableGoldBalance" | "totalLockedGoldBalance" | "nonVotingLockedGoldBalance" | "votingLockedGoldBalance" | "pendingWithdrawalBalance" | "celoUSDValue">
       & { delegations: Array<(
         { __typename?: "CeloDelegation" }
         & Pick<ICeloDelegation, "group" | "totalVotes" | "activeVotes" | "pendingVotes">
@@ -924,7 +924,7 @@ export type ICeloAccountHistoryQuery = (
   { __typename?: "Query" }
   & { celoAccountHistory: Array<(
     { __typename?: "CeloAccountSnapshot" }
-    & Pick<ICeloAccountSnapshot, "snapshotDate" | "address" | "height" | "snapshotReward" | "goldTokenBalance" | "totalLockedGoldBalance" | "nonVotingLockedGoldBalance" | "votingLockedGoldBalance" | "pendingWithdrawalBalance" | "celoUSDValue">
+    & Pick<ICeloAccountSnapshot, "snapshotDate" | "address" | "height" | "snapshotReward" | "availableGoldBalance" | "totalLockedGoldBalance" | "nonVotingLockedGoldBalance" | "votingLockedGoldBalance" | "pendingWithdrawalBalance" | "celoUSDValue">
     & { delegations: Array<(
       { __typename?: "CeloDelegation" }
       & Pick<ICeloDelegation, "group" | "totalVotes" | "activeVotes" | "pendingVotes">
@@ -1497,7 +1497,7 @@ export const AccountBalancesDocument = gql`
       celo {
         address
         height
-        goldTokenBalance
+        availableGoldBalance
         totalLockedGoldBalance
         nonVotingLockedGoldBalance
         votingLockedGoldBalance
@@ -1650,7 +1650,7 @@ export const CeloAccountHistoryDocument = gql`
     address
     height
     snapshotReward
-    goldTokenBalance
+    availableGoldBalance
     totalLockedGoldBalance
     nonVotingLockedGoldBalance
     votingLockedGoldBalance

--- a/packages/utils/src/graphql/types.tsx
+++ b/packages/utils/src/graphql/types.tsx
@@ -134,13 +134,6 @@ export interface ICeloTransactionResult {
   moreResultsExist: Scalars["Boolean"];
 }
 
-export interface ICoin {
-   __typename?: "Coin";
-  id: Scalars["String"];
-  symbol: Scalars["String"];
-  name: Scalars["String"];
-}
-
 export interface ICommissionRates {
    __typename?: "CommissionRates";
   rate: Scalars["String"];
@@ -537,7 +530,6 @@ export interface IQuery {
   distributionParameters: IDistributionParameters;
   /** CoinGecko Price APIs */
   prices: IPrice;
-  coins: Maybe<ICoin[]>;
   fiatCurrencies: IFiatCurrency[];
   /** Oasis APIs */
   oasisTransactions: IOasisTransactionResult;
@@ -948,16 +940,6 @@ export type ICeloTransactionsQuery = (
       & Pick<ICeloTransaction, "date" | "height">
     )> }
   ) }
-);
-
-export interface ICoinsQueryVariables {}
-
-export type ICoinsQuery = (
-  { __typename?: "Query" }
-  & { coins: Maybe<Array<(
-    { __typename?: "Coin" }
-    & Pick<ICoin, "id" | "symbol" | "name">
-  )>> }
 );
 
 export interface ICosmosTransactionsQueryVariables {
@@ -1767,57 +1749,6 @@ export function useCeloTransactionsLazyQuery(baseOptions?: ApolloReactHooks.Lazy
 export type CeloTransactionsQueryHookResult = ReturnType<typeof useCeloTransactionsQuery>;
 export type CeloTransactionsLazyQueryHookResult = ReturnType<typeof useCeloTransactionsLazyQuery>;
 export type CeloTransactionsQueryResult = ApolloReactCommon.QueryResult<ICeloTransactionsQuery, ICeloTransactionsQueryVariables>;
-export const CoinsDocument = gql`
-    query coins {
-  coins {
-    id
-    symbol
-    name
-  }
-}
-    `;
-export type CoinsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<ICoinsQuery, ICoinsQueryVariables>, "query">;
-
-export const CoinsComponent = (props: CoinsComponentProps) => (
-      <ApolloReactComponents.Query<ICoinsQuery, ICoinsQueryVariables> query={CoinsDocument} {...props} />
-    );
-
-export type ICoinsProps<TChildProps = {}> = ApolloReactHoc.DataProps<ICoinsQuery, ICoinsQueryVariables> & TChildProps;
-export function withCoins<TProps, TChildProps = {}>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
-  ICoinsQuery,
-  ICoinsQueryVariables,
-  ICoinsProps<TChildProps>>) {
-    return ApolloReactHoc.withQuery<TProps, ICoinsQuery, ICoinsQueryVariables, ICoinsProps<TChildProps>>(CoinsDocument, {
-      alias: "coins",
-      ...operationOptions,
-    });
-}
-
-/**
- * __useCoinsQuery__
- *
- * To run a query within a React component, call `useCoinsQuery` and pass it any options that fit your needs.
- * When your component renders, `useCoinsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useCoinsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useCoinsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<ICoinsQuery, ICoinsQueryVariables>) {
-        return ApolloReactHooks.useQuery<ICoinsQuery, ICoinsQueryVariables>(CoinsDocument, baseOptions);
-      }
-export function useCoinsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ICoinsQuery, ICoinsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<ICoinsQuery, ICoinsQueryVariables>(CoinsDocument, baseOptions);
-        }
-export type CoinsQueryHookResult = ReturnType<typeof useCoinsQuery>;
-export type CoinsLazyQueryHookResult = ReturnType<typeof useCoinsLazyQuery>;
-export type CoinsQueryResult = ApolloReactCommon.QueryResult<ICoinsQuery, ICoinsQueryVariables>;
 export const CosmosTransactionsDocument = gql`
     query cosmosTransactions($address: String!, $startingPage: Float, $pageSize: Float) {
   cosmosTransactions(address: $address, startingPage: $startingPage, pageSize: $pageSize) {

--- a/packages/utils/src/graphql/types.tsx
+++ b/packages/utils/src/graphql/types.tsx
@@ -119,11 +119,31 @@ export interface ICeloDelegation {
   pendingVotes: Scalars["String"];
 }
 
-/** TODO: Complete the transaction/events types for Celo Network */
 export interface ICeloTransaction {
    __typename?: "CeloTransaction";
-  date: Scalars["String"];
-  height: Scalars["Int"];
+  blockNumber: Scalars["Int"];
+  hash: Scalars["String"];
+  from: Scalars["String"];
+  to: Scalars["String"];
+  details: ICeloTransactionDetails;
+  tags: ICeloTransactionTags[];
+}
+
+export interface ICeloTransactionDetails {
+   __typename?: "CeloTransactionDetails";
+  nonce: Scalars["String"];
+  gasPrice: Scalars["String"];
+  gas: Scalars["String"];
+  feeCurrency: Scalars["String"];
+  gatewayFeeRecipient: Scalars["String"];
+  gatewayFee: Scalars["String"];
+  to: Scalars["String"];
+  value: Scalars["String"];
+  input: Scalars["String"];
+  v: Scalars["String"];
+  r: Scalars["String"];
+  s: Scalars["String"];
+  hash: Scalars["String"];
 }
 
 export interface ICeloTransactionResult {
@@ -132,6 +152,18 @@ export interface ICeloTransactionResult {
   limit: Scalars["Float"];
   data: ICeloTransaction[];
   moreResultsExist: Scalars["Boolean"];
+}
+
+export interface ICeloTransactionTagParameter {
+   __typename?: "CeloTransactionTagParameter";
+  account: Scalars["String"];
+  proposalId: Scalars["String"];
+}
+
+export interface ICeloTransactionTags {
+   __typename?: "CeloTransactionTags";
+  tag: Scalars["String"];
+  parameters: ICeloTransactionTagParameter;
 }
 
 export interface ICommissionRates {
@@ -937,7 +969,18 @@ export type ICeloTransactionsQuery = (
     & Pick<ICeloTransactionResult, "page" | "limit" | "moreResultsExist">
     & { data: Array<(
       { __typename?: "CeloTransaction" }
-      & Pick<ICeloTransaction, "date" | "height">
+      & Pick<ICeloTransaction, "blockNumber" | "hash" | "from" | "to">
+      & { details: (
+        { __typename?: "CeloTransactionDetails" }
+        & Pick<ICeloTransactionDetails, "nonce" | "gasPrice" | "gas" | "feeCurrency" | "gatewayFeeRecipient" | "gatewayFee" | "to" | "value" | "input" | "v" | "r" | "s" | "hash">
+      ), tags: Array<(
+        { __typename?: "CeloTransactionTags" }
+        & Pick<ICeloTransactionTags, "tag">
+        & { parameters: (
+          { __typename?: "CeloTransactionTagParameter" }
+          & Pick<ICeloTransactionTagParameter, "account" | "proposalId">
+        ) }
+      )> }
     )> }
   ) }
 );
@@ -1697,8 +1740,32 @@ export const CeloTransactionsDocument = gql`
     page
     limit
     data {
-      date
-      height
+      blockNumber
+      hash
+      from
+      to
+      details {
+        nonce
+        gasPrice
+        gas
+        feeCurrency
+        gatewayFeeRecipient
+        gatewayFee
+        to
+        value
+        input
+        v
+        r
+        s
+        hash
+      }
+      tags {
+        tag
+        parameters {
+          account
+          proposalId
+        }
+      }
     }
     moreResultsExist
   }

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -135,7 +135,7 @@ const NETWORKS: NetworksMap = {
     ticker: "celo",
     descriptor: "cGLD",
     chainId: "celo",
-    coinGeckoTicker: "celo",
+    coinGeckoTicker: "CGLD",
     cryptoCompareTicker: "CGLD",
     ledgerAppVersion: "1.0.1",
     ledgerAppName: "Celo",

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -142,7 +142,7 @@ const NETWORKS: NetworksMap = {
     ledgerDocsLink: "https://docs.celo.org/celo-gold-holder-guide/ledger",
     // supportsLedger: true,
     supportsLedger: false,
-    supportsFiatPrices: false,
+    supportsFiatPrices: true,
     supportsBalances: true,
     supportsPortfolio: false,
     supportsTransactionsHistory: false,

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -132,7 +132,7 @@ const NETWORKS: NetworksMap = {
     available: false,
     name: "CELO",
     denom: "cGLD",
-    ticker: "celo",
+    ticker: "CGLD",
     descriptor: "cGLD",
     chainId: "celo",
     coinGeckoTicker: "CGLD",

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -136,7 +136,7 @@ const NETWORKS: NetworksMap = {
     descriptor: "cGLD",
     chainId: "celo",
     coinGeckoTicker: "celo",
-    cryptoCompareTicker: "CELO",
+    cryptoCompareTicker: "CGLD",
     ledgerAppVersion: "1.0.1",
     ledgerAppName: "Celo",
     ledgerDocsLink: "https://docs.celo.org/celo-gold-holder-guide/ledger",


### PR DESCRIPTION
**This PR:**

* Add support for Celo fiat price history.
* Remove usage of Coin Gecko API (not support for Celo yet there anyway), and consolidate fiat price data to use Crypto Compare APIs.
* Remove unused `coins` API and related code/tests.
* Add Celo account history API, and update balances and snapshots APIs.
* Work on app back/forward page navigation bugs.
* Restructure app urls, re-enable transactions to link to transactions detail page.
* Begin to add support for rendering Celo transactions and account history in Anthem.
* Add Oasis account history API (still work in progress).