### PR TITLE
Refactor Anthem Routing

### DIFF
--- a/packages/client/src/lib/storage-lib.tsx
+++ b/packages/client/src/lib/storage-lib.tsx
@@ -1,6 +1,5 @@
 import { deriveNetworkFromAddress } from "@anthem/utils";
 import { BANNER_NOTIFICATIONS_KEYS } from "modules/app/store";
-import { ParsedQuery } from "query-string";
 
 /** ===========================================================================
  * Locale Storage Module.

--- a/packages/client/src/lib/storage-lib.tsx
+++ b/packages/client/src/lib/storage-lib.tsx
@@ -35,8 +35,8 @@ class StorageClass {
   /**
    * Stored Address:
    */
-  getAddress = (queryParams: ParsedQuery<string>): string => {
-    const addressParam = queryParams.address;
+  getAddress = (urlAddress?: string): string => {
+    const addressParam = urlAddress;
 
     if (typeof addressParam === "string") {
       return addressParam;

--- a/packages/client/src/lib/storage-lib.tsx
+++ b/packages/client/src/lib/storage-lib.tsx
@@ -35,10 +35,8 @@ class StorageClass {
    * Stored Address:
    */
   getAddress = (urlAddress?: string): string => {
-    const addressParam = urlAddress;
-
-    if (typeof addressParam === "string") {
-      return addressParam;
+    if (urlAddress && typeof urlAddress === "string") {
+      return urlAddress;
     } else {
       const address = this.getItem(KEYS.ADDRESS_KEY);
       if (address) {

--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -74,7 +74,7 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
       // Try to initialize the transactions page from the url
       const paramsPage = Number(params.page);
       const page = !isNaN(paramsPage) ? paramsPage : 1;
-      const network = initializeNetwork(location.pathname, address);
+      const network = initializeNetwork(window.location.pathname, address);
 
       return Actions.initializeAppSuccess({
         address,

--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -24,6 +24,7 @@ import {
   tap,
 } from "rxjs/operators";
 import {
+  getAddressFromUrl,
   getQueryParamsFromUrl,
   initializeNetwork,
   wait,
@@ -51,9 +52,9 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
       Analytics.initialize();
     }),
     map(() => {
-      console.log(window.location);
       const params = getQueryParamsFromUrl(window.location.search);
-      let address = StorageModule.getAddress(params);
+      const urlAddress = getAddressFromUrl(window.location.pathname);
+      let address = StorageModule.getAddress(urlAddress);
       const { tString } = i18nSelector(state$.value);
 
       // Convert validator address to operator addresses

--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -1,8 +1,6 @@
 import {
   CosmosAccountBalancesDocument,
   CosmosTransactionsDocument,
-  deriveNetworkFromAddress,
-  NETWORKS,
   validatorAddressToOperatorAddress,
 } from "@anthem/utils";
 import { graphqlSelector } from "graphql/queries";

--- a/packages/client/src/modules/app/store.ts
+++ b/packages/client/src/modules/app/store.ts
@@ -123,7 +123,7 @@ const app = createReducer<AppState, ActionTypes>(initialAppState)
     const { pathname } = action.payload;
     const chartViewActive = onPageWhichIncludesAddressParam(pathname);
     if (chartViewActive) {
-      const tab = pathname.split("/")[1];
+      const tab = pathname.split("/")[2];
       const validTab = isValidChartTab(tab);
       if (validTab) {
         activeChartTab = validTab;

--- a/packages/client/src/modules/app/store.ts
+++ b/packages/client/src/modules/app/store.ts
@@ -2,7 +2,10 @@ import { Pathname, Search } from "history";
 import { PORTFOLIO_CHART_TYPES } from "i18n/english";
 import StorageModule from "lib/storage-lib";
 import { combineReducers } from "redux";
-import { isValidChartTab, onChartView } from "tools/client-utils";
+import {
+  isValidChartTab,
+  onPageWhichIncludesAddressParam,
+} from "tools/client-utils";
 import { createReducer } from "typesafe-actions";
 import actions, { ActionTypes } from "./actions";
 
@@ -118,7 +121,7 @@ const app = createReducer<AppState, ActionTypes>(initialAppState)
 
     // Update the active chart tab if viewing the portfolio
     const { pathname } = action.payload;
-    const chartViewActive = onChartView(pathname);
+    const chartViewActive = onPageWhichIncludesAddressParam(pathname);
     if (chartViewActive) {
       const tab = pathname.split("/")[1];
       const validTab = isValidChartTab(tab);

--- a/packages/client/src/modules/ledger/epics.ts
+++ b/packages/client/src/modules/ledger/epics.ts
@@ -412,7 +412,11 @@ const searchTransactionNavigationEpic: EpicSignature = (
   return action$.pipe(
     filter(isActionOf(Actions.searchTransactionByHash)),
     pluck("payload"),
-    tap(hash => deps.router.push({ pathname: `/txs/${hash.toLowerCase()}` })),
+    tap(hash => {
+      const { network } = state$.value.ledger.ledger;
+      const pathname = `/${network.name.toLowerCase()}/txs/${hash.toLowerCase()}`;
+      deps.router.push({ pathname });
+    }),
     ignoreElements(),
   );
 };

--- a/packages/client/src/modules/root.ts
+++ b/packages/client/src/modules/root.ts
@@ -109,6 +109,7 @@ const rootEpic = (action$: any, store$: any, dependencies: any) => {
 };
 
 const resubscribeOnError = (error: any, source: any) => {
+  console.log(error);
   // Handle error side effects
   return source;
 };

--- a/packages/client/src/modules/root.ts
+++ b/packages/client/src/modules/root.ts
@@ -109,7 +109,8 @@ const rootEpic = (action$: any, store$: any, dependencies: any) => {
 };
 
 const resubscribeOnError = (error: any, source: any) => {
-  console.log(error);
+  // Log the error:
+  console.log("[ERROR]: Uncaught error from epics: ", error);
   // Handle error side effects
   return source;
 };

--- a/packages/client/src/test/client-utils.test.ts
+++ b/packages/client/src/test/client-utils.test.ts
@@ -177,13 +177,17 @@ describe("utils", () => {
   });
 
   test("onActiveRoute matches routes correctly", () => {
-    expect(onActiveRoute("/dashboard", "Dashboard")).toBeTruthy();
-    expect(onActiveRoute("/wallet", "Wallet")).toBeTruthy();
-    expect(onActiveRoute("/governance", "Governance")).toBeTruthy();
+    expect(
+      onActiveRoute("/cosmos/dashboard", "/cosmos/dashboard"),
+    ).toBeTruthy();
+    expect(onActiveRoute("/cosmos/wallet", "/cosmos/wallet")).toBeTruthy();
+    expect(
+      onActiveRoute("/cosmos/governance", "/cosmos/governance"),
+    ).toBeTruthy();
 
-    expect(onActiveRoute("/wallet", "Dashboard")).toBeFalsy();
-    expect(onActiveRoute("/settings", "Dashboard")).toBeFalsy();
-    expect(onActiveRoute("/help", "helped")).toBeFalsy();
+    expect(onActiveRoute("/cosmos/wallet", "wallet")).toBeFalsy();
+    expect(onActiveRoute("/cosmos/settings", "settings")).toBeFalsy();
+    expect(onActiveRoute("/cosmos/help", "help")).toBeFalsy();
   });
 
   test("getQueryParamsFromUrl", () => {

--- a/packages/client/src/test/storage-module.test.ts
+++ b/packages/client/src/test/storage-module.test.ts
@@ -3,10 +3,10 @@ import StorageModule from "lib/storage-lib";
 describe("storage-utils", () => {
   test("localStorage address", () => {
     const address = "cosmos16nte2qf5l0u39s86wcwu4fff4vdtvg7yn3uksu";
-    let result = StorageModule.getAddress({});
+    let result = StorageModule.getAddress("");
     expect(result).toBe("");
     StorageModule.setAddress(address);
-    result = StorageModule.getAddress({});
+    result = StorageModule.getAddress("");
     expect(result).toBe(address);
   });
 

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -110,35 +110,16 @@ export const identity = <T extends {}>(x: T): T => x;
  * Parse the query parameters from the current url.
  */
 export const getQueryParamsFromUrl = (paramString: string) => {
-  // Parse manually to check Oasis addresses, which can contain unusual characters
-  const qs = paramString.replace("?", "");
-  const pairs = qs.split("&");
-  const params: { [key: string]: string } = pairs.reduce((result, pair) => {
-    // Oasis address may have +, /, and = characters...
-    if (pair.includes("address=")) {
-      const address = pair.replace("address=", "");
-      return { ...result, address };
-    } else {
-      const [key, value] = pair.split("=");
-      return { ...result, [key]: value };
-    }
-  }, {});
-
-  if (!!params.address) {
-    const { address } = params;
-    const oasisAddressProxyTest = address.length === 44;
-    if (oasisAddressProxyTest) {
-      return params as ParsedQuery<string>;
-    }
-  }
-
   return queryString.parse(paramString);
 };
 
 /**
  * Initialize the network when the app launches.
  */
-export const initializeNetwork = (url: string, address: string): NetworkDefinition => {
+export const initializeNetwork = (
+  url: string,
+  address: string,
+): NetworkDefinition => {
   const network = url.split("/")[1];
   const networkDefinition = NETWORKS[network.toUpperCase()];
   if (networkDefinition) {

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -405,10 +405,13 @@ export const onPath = (url: string, pathString: string): boolean => {
 };
 
 /**
- * Return true if a URL pathname is on the chart (dashboard) view.
+ * Return true if a URL pathname is on a page which includes the
+ * address= param.
  */
-export const onChartView = (pathname: string) => {
-  return /total|available|staking|rewards|commissions/.test(pathname);
+export const onPageWhichIncludesAddressParam = (pathname: string) => {
+  return /total|available|staking|rewards|commissions|delegate|governance/.test(
+    pathname,
+  );
 };
 
 /**

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -89,16 +89,16 @@ export enum OASIS_ADDRESS_ENUM {
 /**
  * Determine if a given route link is on the current active route.
  */
-export const onActiveRoute = (pathName: string, routeName: string): boolean => {
-  return pathName === routeName;
+export const onActiveRoute = (path: string, route: string): boolean => {
+  return path === route;
 };
 
 /**
  * Determine if the given tab is active given the current route.
  */
-export const onActiveTab = (pathName: string, tabName: string): boolean => {
-  const path = pathName.split("/")[1];
-  return !!path && path.toLowerCase() === tabName.toLowerCase();
+export const onActiveTab = (pathname: string, tab: string): boolean => {
+  const path = pathname.split("/")[2];
+  return !!path && path.toLowerCase() === tab.toLowerCase();
 };
 
 /**
@@ -118,6 +118,77 @@ export const getQueryParamsFromUrl = (paramString: string) => {
  */
 export const getAddressFromUrl = (url: string) => {
   return url.split("/")[3];
+};
+
+/**
+ * Crudely determine if some path string is included in the current URL.
+ */
+export const onPath = (url: string, pathString: string): boolean => {
+  return url.includes(pathString);
+};
+
+/**
+ * Return true if a URL pathname is on a page which includes the
+ * address= param.
+ */
+export const onPageWhichIncludesAddressParam = (pathname: string) => {
+  return /total|available|staking|rewards|commissions|delegate|governance/.test(
+    pathname,
+  );
+};
+
+/**
+ * Check if a pathname includes a chart view.
+ */
+export const onChartTab = (pathname: string) => {
+  return /total|available|staking|rewards|commissions/.test(pathname);
+};
+
+/**
+ * Valid chart tab keys.
+ */
+export const CHART_TABS: ReadonlyArray<PORTFOLIO_CHART_TYPES> = [
+  "TOTAL",
+  "AVAILABLE",
+  "STAKING",
+  "REWARDS",
+  "COMMISSIONS",
+];
+
+/**
+ *  Determine if a string is a valid chart tab key.
+ */
+export const isValidChartTab = (
+  tab: string,
+): Nullable<PORTFOLIO_CHART_TYPES> => {
+  // @ts-ignore
+  if (new Set(CHART_TABS).has(tab.toUpperCase())) {
+    return tab.toUpperCase() as PORTFOLIO_CHART_TYPES;
+  } else {
+    return null;
+  }
+};
+
+/**
+ * Return information on which dashboard tab the user is viewing from the
+ * given url location.
+ */
+export const getPortfolioTypeFromUrl = (
+  path: string,
+): PORTFOLIO_CHART_TYPES | null => {
+  if (onPath(path, "/total")) {
+    return "TOTAL";
+  } else if (onPath(path, "/available")) {
+    return "AVAILABLE";
+  } else if (onPath(path, "/rewards")) {
+    return "REWARDS";
+  } else if (onPath(path, "/staking")) {
+    return "STAKING";
+  } else if (onPath(path, "/commissions")) {
+    return "COMMISSIONS";
+  }
+
+  return null;
 };
 
 /**
@@ -397,70 +468,6 @@ export const canRenderGraphQL = (graphqlProps: {
   error?: ApolloError;
 }): boolean => {
   return !graphqlProps.loading && !graphqlProps.error && graphqlProps.data;
-};
-
-/**
- * Crudely determine if some path string is included in the current URL.
- */
-export const onPath = (url: string, pathString: string): boolean => {
-  return url.includes(pathString);
-};
-
-/**
- * Return true if a URL pathname is on a page which includes the
- * address= param.
- */
-export const onPageWhichIncludesAddressParam = (pathname: string) => {
-  return /total|available|staking|rewards|commissions|delegate|governance/.test(
-    pathname,
-  );
-};
-
-/**
- * Valid chart tab keys.
- */
-export const CHART_TABS: ReadonlyArray<PORTFOLIO_CHART_TYPES> = [
-  "TOTAL",
-  "AVAILABLE",
-  "STAKING",
-  "REWARDS",
-  "COMMISSIONS",
-];
-
-/**
- *  Determine if a string is a valid chart tab key.
- */
-export const isValidChartTab = (
-  tab: string,
-): Nullable<PORTFOLIO_CHART_TYPES> => {
-  // @ts-ignore
-  if (new Set(CHART_TABS).has(tab.toUpperCase())) {
-    return tab.toUpperCase() as PORTFOLIO_CHART_TYPES;
-  } else {
-    return null;
-  }
-};
-
-/**
- * Return information on which dashboard tab the user is viewing from the
- * given url location.
- */
-export const getPortfolioTypeFromUrl = (
-  path: string,
-): PORTFOLIO_CHART_TYPES | null => {
-  if (onPath(path, "/total")) {
-    return "TOTAL";
-  } else if (onPath(path, "/available")) {
-    return "AVAILABLE";
-  } else if (onPath(path, "/rewards")) {
-    return "REWARDS";
-  } else if (onPath(path, "/staking")) {
-    return "STAKING";
-  } else if (onPath(path, "/commissions")) {
-    return "COMMISSIONS";
-  }
-
-  return null;
 };
 
 /**

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -1,6 +1,7 @@
 import {
   assertUnreachable,
   COIN_DENOMS,
+  deriveNetworkFromAddress,
   getValidatorAddressFromDelegatorAddress,
   ICeloValidatorGroup,
   ICosmosAccountBalances,
@@ -11,6 +12,7 @@ import {
   IUnbondingDelegationEntry,
   NETWORK_NAME,
   NetworkDefinition,
+  NETWORKS,
   RequestFailure,
 } from "@anthem/utils";
 import { ApolloError } from "apollo-client";
@@ -131,6 +133,20 @@ export const getQueryParamsFromUrl = (paramString: string) => {
   }
 
   return queryString.parse(paramString);
+};
+
+/**
+ * Initialize the network when the app launches.
+ */
+export const initializeNetwork = (url: string, address: string): NetworkDefinition => {
+  const network = url.split("/")[1];
+  const networkDefinition = NETWORKS[network.toUpperCase()];
+  if (networkDefinition) {
+    return networkDefinition;
+  } else {
+    const derivedNetwork = deriveNetworkFromAddress(address);
+    return derivedNetwork;
+  }
 };
 
 /**

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -114,6 +114,13 @@ export const getQueryParamsFromUrl = (paramString: string) => {
 };
 
 /**
+ * Get address from url. The urls schemes are :network/:page/:address.
+ */
+export const getAddressFromUrl = (url: string) => {
+  return url.split("/")[3];
+};
+
+/**
  * Initialize the network when the app launches.
  */
 export const initializeNetwork = (

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -131,9 +131,11 @@ export const initializeNetwork = (
   const networkDefinition = NETWORKS[network.toUpperCase()];
   if (networkDefinition) {
     return networkDefinition;
-  } else {
+  } else if (address) {
     const derivedNetwork = deriveNetworkFromAddress(address);
     return derivedNetwork;
+  } else {
+    return NETWORKS.COSMOS;
   }
 };
 

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -88,8 +88,7 @@ export enum OASIS_ADDRESS_ENUM {
  * Determine if a given route link is on the current active route.
  */
 export const onActiveRoute = (pathName: string, routeName: string): boolean => {
-  const path = pathName.split("/")[1];
-  return !!path && path.toLowerCase() === routeName.toLowerCase();
+  return pathName === routeName;
 };
 
 /**

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -18,7 +18,7 @@ import {
 import { ApolloError } from "apollo-client";
 import BigNumber from "bignumber.js";
 import { PORTFOLIO_CHART_TYPES } from "i18n/english";
-import queryString, { ParsedQuery } from "query-string";
+import queryString from "query-string";
 import { AvailableReward } from "ui/CreateTransactionForm";
 import Toast from "ui/Toast";
 import {

--- a/packages/client/src/tools/validation-utils.ts
+++ b/packages/client/src/tools/validation-utils.ts
@@ -84,12 +84,10 @@ export const validateNetworkAddress = (
     );
   }
 
+  /**
+   * TODO: Improve Celo address validation.
+   */
   if (address.substring(0, 2) === "0x" && address.length === 42) {
-    console.warn("[TODO]: Fix address validation for Celo addresses!");
-    return "";
-  }
-
-  if (address.substring(0, 5) === "oasis") {
     return "";
   }
 

--- a/packages/client/src/ui/LedgerDialogWorkflow.tsx
+++ b/packages/client/src/ui/LedgerDialogWorkflow.tsx
@@ -367,7 +367,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
                       replace
                       key={address}
                       style={{ marginTop: 4, marginBottom: 2 }}
-                      to={`/${activeChartTab.toLowerCase()}?address=${address}`}
+                      to={`/${network.name.toLowerCase()}/${activeChartTab.toLowerCase()}?address=${address}`}
                     >
                       <Row style={{ justifyContent: "flex-start" }}>
                         <NetworkLogoIcon
@@ -400,7 +400,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
                 <Link
                   replace
                   style={{ marginTop: 2, marginBottom: 2 }}
-                  to={`/${activeChartTab.toLowerCase()}?address=cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd`}
+                  to={`/cosmos/${activeChartTab.toLowerCase()}?address=cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd`}
                 >
                   <Row style={{ justifyContent: "flex-start" }}>
                     <NetworkLogoIcon
@@ -422,7 +422,7 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
                 <Link
                   replace
                   style={{ marginTop: 2, marginBottom: 2 }}
-                  to={`/${activeChartTab.toLowerCase()}?address=oasis1qrllkgqgqheus3qvq69wzsmh7799agg8lgsyecfq`}
+                  to={`/oasis/${activeChartTab.toLowerCase()}?address=oasis1qrllkgqgqheus3qvq69wzsmh7799agg8lgsyecfq`}
                 >
                   <Row style={{ justifyContent: "flex-start" }}>
                     <NetworkLogoIcon

--- a/packages/client/src/ui/SideMenu.tsx
+++ b/packages/client/src/ui/SideMenu.tsx
@@ -87,9 +87,9 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         path={pathname}
         closeHandler={close}
         key="Dashboard"
-        route={`${dashboardTab}`}
         title={tString("Dashboard")}
         icon={IconNames.TIMELINE_BAR_CHART}
+        route={`/${name.toLowerCase()}/${dashboardTab.toLowerCase()}`}
       />,
       <NavItem
         key="Staking"

--- a/packages/client/src/ui/SideMenu.tsx
+++ b/packages/client/src/ui/SideMenu.tsx
@@ -69,6 +69,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
     const { t, tString } = i18n;
     const { pathname } = location;
     const { isDesktop } = settings;
+    const { name } = network;
 
     const { mobileMenuOpen } = this.state;
     const open = () => this.setMobileMenuState(true);
@@ -91,20 +92,20 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         icon={IconNames.TIMELINE_BAR_CHART}
       />,
       <NavItem
+        key="Staking"
+        title="Staking"
         path={pathname}
         closeHandler={close}
-        key="Staking"
-        route="Delegate"
-        title="Staking"
         icon={IconNames.BANK_ACCOUNT}
+        route={`/${name.toLowerCase()}/delegate`}
       />,
       <NavItem
+        key="Governance"
         path={pathname}
         closeHandler={close}
-        key="Governance"
-        route="Governance"
         title={tString("Governance")}
         icon={IconNames.TAKE_ACTION}
+        route={`/${name.toLowerCase()}/governance`}
       />,
     ];
 
@@ -114,7 +115,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
           path={pathname}
           closeHandler={close}
           key="Settings"
-          route="Settings"
+          route="/settings"
           title={tString("Settings")}
           icon={IconNames.COG}
         />
@@ -123,7 +124,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         path={pathname}
         closeHandler={close}
         key="Help"
-        route="Help"
+        route="/help"
         title={tString("Help")}
         icon={IconNames.LIGHTBULB}
       />,
@@ -144,7 +145,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
             this.props.openLogoutMenu();
           }}
           key="Logout"
-          route="Logout"
+          route="/logout"
           title={tString("Logout")}
           icon={IconNames.LOG_OUT}
         />
@@ -406,11 +407,7 @@ const NavItem = ({ route, title, icon, path, closeHandler }: INavItemProps) => {
   const active = onActiveRoute(path, route);
   const cypressLabel = `${title.toLowerCase()}-navigation-link`;
   return (
-    <Link
-      onClick={closeHandler}
-      data-cy={cypressLabel}
-      to={`/${route.toLowerCase()}`}
-    >
+    <Link onClick={closeHandler} data-cy={cypressLabel} to={route}>
       <NavLinkContainer activeRoute={active}>
         <Icon
           icon={icon}

--- a/packages/client/src/ui/SideMenu.tsx
+++ b/packages/client/src/ui/SideMenu.tsx
@@ -405,7 +405,6 @@ interface INavItemProps {
 
 const NavItem = ({ route, title, icon, path, closeHandler }: INavItemProps) => {
   const active = onActiveRoute(path, route);
-  console.log(path, route, active);
   const cypressLabel = `${title.toLowerCase()}-navigation-link`;
   return (
     <Link onClick={closeHandler} data-cy={cypressLabel} to={route}>

--- a/packages/client/src/ui/SideMenu.tsx
+++ b/packages/client/src/ui/SideMenu.tsx
@@ -75,7 +75,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
     const open = () => this.setMobileMenuState(true);
     const close = () => this.setMobileMenuState(false);
 
-    const dashboardTab = this.props.app.activeChartTab;
+    const { activeChartTab } = this.props.app;
     const ledgerConnected = this.props.ledger.connected;
     const validator = this.getValidatorFromDelegatorAddressIfExists();
 
@@ -89,7 +89,7 @@ class SideMenuComponent extends React.Component<IProps, IState> {
         key="Dashboard"
         title={tString("Dashboard")}
         icon={IconNames.TIMELINE_BAR_CHART}
-        route={`/${name.toLowerCase()}/${dashboardTab.toLowerCase()}`}
+        route={`/${name.toLowerCase()}/${activeChartTab.toLowerCase()}`}
       />,
       <NavItem
         key="Staking"
@@ -405,6 +405,7 @@ interface INavItemProps {
 
 const NavItem = ({ route, title, icon, path, closeHandler }: INavItemProps) => {
   const active = onActiveRoute(path, route);
+  console.log(path, route, active);
   const cypressLabel = `${title.toLowerCase()}-navigation-link`;
   return (
     <Link onClick={closeHandler} data-cy={cypressLabel} to={route}>

--- a/packages/client/src/ui/balances/BalancesComponents.tsx
+++ b/packages/client/src/ui/balances/BalancesComponents.tsx
@@ -249,7 +249,7 @@ class CosmosBalancesComponent extends React.Component<
           <ActionContainer>
             <H5>{tString("What do you want to do?")}</H5>
             <DelegationControlsContainer>
-              <Link to="/delegate">
+              <Link to="/cosmos/delegate">
                 <Button
                   style={{ width: 125, marginRight: 12 }}
                   onClick={() => null}
@@ -446,7 +446,7 @@ class CeloBalancesComponent extends React.Component<
         <ActionContainer>
           <H5>Celo Ledger Transactions</H5>
           <DelegationControlsContainer>
-            <Link to="/delegate">
+            <Link to="/celo/delegate">
               <Button
                 style={{ width: 125, marginRight: 12 }}
                 onClick={() => null}

--- a/packages/client/src/ui/containers/RoutesContainer.tsx
+++ b/packages/client/src/ui/containers/RoutesContainer.tsx
@@ -36,7 +36,7 @@ import ValidatorsPage from "ui/validators/ValidatorsSwitchContainer";
 
 class RoutesContainer extends React.Component<IProps> {
   render(): JSX.Element {
-    const { address, settings } = this.props;
+    const { address, network, settings } = this.props;
     const SHOW_LANDING_PAGE = !address;
     // Alternate welcome page:
     // NOTE: To enable, also redirect to /welcome in the ledger logoutEpic
@@ -73,7 +73,7 @@ class RoutesContainer extends React.Component<IProps> {
               exact
               key={2}
               component={DashboardPage}
-              path="/:path(total|available|staking|rewards|commissions)/:address"
+              path="/:network/:path(total|available|staking|rewards|commissions)"
             />
             <Route
               key={3}
@@ -82,12 +82,12 @@ class RoutesContainer extends React.Component<IProps> {
             />
             <Route
               key={4}
-              path="/:network/delegate/:address"
+              path="/:network/delegate"
               component={ValidatorsPage}
             />
             <Route
               key={5}
-              path="/:network/governance/:address"
+              path="/:network/governance"
               component={GovernanceSwitchContainer}
             />
             <Route key={6} path="/help" component={HelpPage} />
@@ -96,7 +96,7 @@ class RoutesContainer extends React.Component<IProps> {
               key={7}
               component={() =>
                 !!address ? (
-                  <Redirect to="/total" />
+                  <Redirect to={`/${network.name.toLowerCase()}/total`} />
                 ) : (
                   <Redirect to="/welcome" />
                 )
@@ -186,6 +186,7 @@ const DevLabelText = styled.p`
 const mapStateToProps = (state: ReduxStoreState) => ({
   settings: Modules.selectors.settings(state),
   address: Modules.selectors.ledger.addressSelector(state),
+  network: Modules.selectors.ledger.networkSelector(state),
 });
 
 type ConnectProps = ReturnType<typeof mapStateToProps>;

--- a/packages/client/src/ui/containers/RoutesContainer.tsx
+++ b/packages/client/src/ui/containers/RoutesContainer.tsx
@@ -77,7 +77,7 @@ class RoutesContainer extends React.Component<IProps> {
             />
             <Route
               key={3}
-              path="/txs/*"
+              path="/:network/txs/*"
               component={TransactionDetailContainer}
             />
             <Route key={4} path="/delegate" component={ValidatorsPage} />

--- a/packages/client/src/ui/containers/RoutesContainer.tsx
+++ b/packages/client/src/ui/containers/RoutesContainer.tsx
@@ -41,6 +41,7 @@ class RoutesContainer extends React.Component<IProps> {
     // Alternate welcome page:
     // NOTE: To enable, also redirect to /welcome in the ledger logoutEpic
     // const SHOW_LANDING_PAGE = history.location.pathname === "/login";
+    // Update with a network UI component: NetworkOverview/NetworkSummary.
 
     if (SHOW_LANDING_PAGE) {
       return (

--- a/packages/client/src/ui/containers/RoutesContainer.tsx
+++ b/packages/client/src/ui/containers/RoutesContainer.tsx
@@ -73,7 +73,7 @@ class RoutesContainer extends React.Component<IProps> {
               exact
               key={2}
               component={DashboardPage}
-              path="/:path(total|available|staking|rewards|commissions)"
+              path="/:path(total|available|staking|rewards|commissions)/:address"
             />
             <Route
               key={3}
@@ -82,12 +82,12 @@ class RoutesContainer extends React.Component<IProps> {
             />
             <Route
               key={4}
-              path="/:network/delegate"
+              path="/:network/delegate/:address"
               component={ValidatorsPage}
             />
             <Route
               key={5}
-              path="/:network/governance"
+              path="/:network/governance/:address"
               component={GovernanceSwitchContainer}
             />
             <Route key={6} path="/help" component={HelpPage} />

--- a/packages/client/src/ui/containers/RoutesContainer.tsx
+++ b/packages/client/src/ui/containers/RoutesContainer.tsx
@@ -80,10 +80,14 @@ class RoutesContainer extends React.Component<IProps> {
               path="/:network/txs/*"
               component={TransactionDetailContainer}
             />
-            <Route key={4} path="/delegate" component={ValidatorsPage} />
+            <Route
+              key={4}
+              path="/:network/delegate"
+              component={ValidatorsPage}
+            />
             <Route
               key={5}
-              path="/governance"
+              path="/:network/governance"
               component={GovernanceSwitchContainer}
             />
             <Route key={6} path="/help" component={HelpPage} />

--- a/packages/client/src/ui/pages/DashboardPage.tsx
+++ b/packages/client/src/ui/pages/DashboardPage.tsx
@@ -55,7 +55,7 @@ import TransactionSwitchContainer from "ui/transactions/TransactionSwitchContain
 class DashboardPage extends React.Component<IProps> {
   componentDidMount() {
     const tab = window.location.pathname.split("/")[2];
-    const validTab = isValidChartTab(tab);
+    const validTab = tab && isValidChartTab(tab);
     if (validTab) {
       this.props.setActiveChartTab(validTab);
     }

--- a/packages/client/src/ui/pages/DashboardPage.tsx
+++ b/packages/client/src/ui/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { NetworkDefinition } from "@anthem/utils";
 import {
   Button,
   Card,
@@ -53,7 +54,7 @@ import TransactionSwitchContainer from "ui/transactions/TransactionSwitchContain
 
 class DashboardPage extends React.Component<IProps> {
   componentDidMount() {
-    const tab = window.location.pathname.split("/")[1];
+    const tab = window.location.pathname.split("/")[2];
     const validTab = isValidChartTab(tab);
     if (validTab) {
       this.props.setActiveChartTab(validTab);
@@ -157,12 +158,14 @@ class DashboardPage extends React.Component<IProps> {
     const {
       i18n,
       address,
+      ledger,
       history,
       settings,
       location,
       cosmosAccountHistory,
     } = this.props;
     const { tString } = i18n;
+    const { network } = ledger;
     const { pathname } = location;
 
     const commissionsLinkAvailable = shouldShowCommissionsLink(
@@ -188,6 +191,7 @@ class DashboardPage extends React.Component<IProps> {
                 <DashboardNavigationLink
                   key={title}
                   title={title}
+                  network={network}
                   address={address}
                   pathname={pathname}
                   localizedTitle={tString(title as PORTFOLIO_CHART_TYPES)}
@@ -209,6 +213,7 @@ class DashboardPage extends React.Component<IProps> {
                     title,
                     address,
                     history,
+                    network,
                     pathname,
                     localizedTitle: tString(title),
                   }),
@@ -336,6 +341,7 @@ interface INavItemProps {
   address: string;
   pathname: string;
   localizedTitle: string;
+  network: NetworkDefinition;
   title: PORTFOLIO_CHART_TYPES;
 }
 
@@ -371,11 +377,13 @@ const ExpandCollapseIcon = ({ onClick }: { onClick: () => void }) => (
 
 const DashboardNavigationLink = ({
   title,
+  address,
+  network,
   pathname,
   localizedTitle,
 }: INavItemProps) => {
   const active = onActiveTab(pathname, title);
-  const path = `/${title.toLowerCase()}`;
+  const path = `${title.toLowerCase()}?address=${address}`;
   const onClickFunction = () => runAnalyticsForTab(title);
   return (
     <Link
@@ -411,12 +419,14 @@ const NavLinkContainer = styled.div`
 
 const getMobileDashboardNavigationLink = ({
   title,
+  address,
+  network,
   history,
   pathname,
   localizedTitle,
 }: INavItemProps & { history: History }) => {
   const active = onActiveRoute(pathname, localizedTitle);
-  const path = `/${title.toLowerCase()}`;
+  const path = `/${network.name.toLowerCase()}/${title.toLowerCase()}?address=${address}`;
   const onClickFunction = () => {
     history.push(path);
     runAnalyticsForTab(title);

--- a/packages/client/src/ui/portfolio/CeloPortfolio.tsx
+++ b/packages/client/src/ui/portfolio/CeloPortfolio.tsx
@@ -31,6 +31,7 @@ import {
 import { composeWithProps } from "tools/context-utils";
 import { denomToUnit } from "tools/currency-utils";
 import { toDateKeyCelo } from "tools/date-utils";
+import { addValuesInList } from "tools/math-utils";
 import { GraphQLGuardComponentMultipleQueries } from "ui/GraphQLGuardComponents";
 import Toast from "ui/Toast";
 import CurrencySettingsToggle from "../CurrencySettingToggle";
@@ -259,7 +260,11 @@ const getChartData = (
     let value = "";
     switch (type) {
       case "TOTAL":
-        value = x.totalLockedGoldBalance;
+        value = addValuesInList([
+          x.totalLockedGoldBalance,
+          x.availableGoldBalance,
+          x.pendingWithdrawalBalance,
+        ]);
         break;
       case "AVAILABLE":
         value = x.availableGoldBalance;
@@ -320,7 +325,7 @@ const getCeloCSV = (
     `Voting Locked Gold Balance (${coin})`,
     `Pending Withdrawal Balance (${coin})`,
     `Reward (${coin})`,
-    `cUSD Balance (${coin})`,
+    `cUSD Balance`,
   ];
 
   // Add info text about the address and network

--- a/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
@@ -116,7 +116,6 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
 
   renderHash = (transaction: ICeloTransaction) => {
     const { hash } = transaction;
-    const { name } = this.props.network;
 
     const TxHashLink = this.props.isDetailView ? (
       <ClickableEventRow onClick={() => copyTextToClipboard(hash)}>
@@ -131,10 +130,7 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link
-        data-cy="transaction-hash-link"
-        to={`${name.toLowerCase()}/txs/${hash}`}
-      >
+      <Link data-cy="transaction-hash-link" to={`txs/${hash}`}>
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
@@ -1,7 +1,7 @@
 import { ICeloTransaction, NetworkDefinition } from "@anthem/utils";
 import { Card, Code, Elevation, Position, Tooltip } from "@blueprintjs/core";
 import { CeloLogo } from "assets/icons";
-import { LinkIcon, OasisGenericEvent } from "assets/images";
+import { LinkIcon } from "assets/images";
 import { FiatCurrency } from "constants/fiat";
 import { ILocale } from "i18n/catalog";
 import Modules from "modules/root";

--- a/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
@@ -116,6 +116,7 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
 
   renderHash = (transaction: ICeloTransaction) => {
     const { hash } = transaction;
+    const { name } = this.props.network;
 
     const TxHashLink = this.props.isDetailView ? (
       <ClickableEventRow onClick={() => copyTextToClipboard(hash)}>
@@ -130,7 +131,10 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link to={`/txs/${hash}`} data-cy="transaction-hash-link">
+      <Link
+        data-cy="transaction-hash-link"
+        to={`${name.toLowerCase()}/txs/${hash}`}
+      >
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CeloTransactionListItem.tsx
@@ -101,9 +101,7 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
     const { blockNumber } = transaction;
     return (
       <EventRowItem style={{ minWidth: 300 }}>
-        <EventIconBox>
-          <OasisGenericEvent />
-        </EventIconBox>
+        <EventIconBox />
         <EventContextBox>
           <EventText style={{ fontWeight: "bold" }}>Block Number</EventText>
           <EventText data-cy="transaction-block-number">
@@ -251,7 +249,7 @@ class CeloTransactionListItem extends React.PureComponent<IProps, {}> {
           <EventContextBox>
             <Row>
               <EventText style={{ fontWeight: "bold" }}>
-                Internal Transaction Data
+                Contract Call
               </EventText>
             </Row>
           </EventContextBox>

--- a/packages/client/src/ui/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CosmosTransactionListItem.tsx
@@ -342,7 +342,6 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   };
 
   renderTransactionHashLink = (hash: string, chain: string) => {
-    const { name } = this.props.network;
     // If viewing in the transaction list view, render a link to the detail
     // view. Otherwise just render a link to copy the hash.
     const TxHashLink = this.props.isDetailView ? (
@@ -356,10 +355,7 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link
-        data-cy="transaction-hash-link"
-        to={`${name.toLowerCase()}/txs/${hash}`}
-      >
+      <Link data-cy="transaction-hash-link" to={`txs/${hash}`}>
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/CosmosTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/CosmosTransactionListItem.tsx
@@ -342,6 +342,7 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
   };
 
   renderTransactionHashLink = (hash: string, chain: string) => {
+    const { name } = this.props.network;
     // If viewing in the transaction list view, render a link to the detail
     // view. Otherwise just render a link to copy the hash.
     const TxHashLink = this.props.isDetailView ? (
@@ -355,7 +356,10 @@ class CosmosTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link to={`/txs/${hash}`} data-cy="transaction-hash-link">
+      <Link
+        data-cy="transaction-hash-link"
+        to={`${name.toLowerCase()}/txs/${hash}`}
+      >
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
@@ -289,7 +289,6 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
 
   renderHash = () => {
     const { hash } = this.props.transaction;
-    const { name } = this.props.network;
 
     const TxHashLink = this.props.isDetailView ? (
       <ClickableEventRow onClick={() => copyTextToClipboard(hash)}>
@@ -304,10 +303,7 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link
-        data-cy="transaction-hash-link"
-        to={`${name.toLowerCase()}/txs/${hash}`}
-      >
+      <Link data-cy="transaction-hash-link" to={`txs/${hash}`}>
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
@@ -289,6 +289,7 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
 
   renderHash = () => {
     const { hash } = this.props.transaction;
+    const { name } = this.props.network;
 
     const TxHashLink = this.props.isDetailView ? (
       <ClickableEventRow onClick={() => copyTextToClipboard(hash)}>
@@ -303,7 +304,10 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
         </EventContextBox>
       </ClickableEventRow>
     ) : (
-      <Link to={`/txs/${hash}`} data-cy="transaction-hash-link">
+      <Link
+        to={`${name.toLowerCase()}/txs/${hash}`}
+        data-cy="transaction-hash-link"
+      >
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>
             <LinkIcon />

--- a/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
@@ -305,8 +305,8 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
       </ClickableEventRow>
     ) : (
       <Link
-        to={`${name.toLowerCase()}/txs/${hash}`}
         data-cy="transaction-hash-link"
+        to={`${name.toLowerCase()}/txs/${hash}`}
       >
         <ClickableEventRow onClick={() => null}>
           <EventIconBox>

--- a/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
+++ b/packages/client/src/ui/transactions/OasisTransactionListItem.tsx
@@ -193,9 +193,7 @@ class OasisTransactionListItem extends React.PureComponent<IProps, {}> {
     const { height } = transaction;
     return (
       <EventRowItem style={{ minWidth: 200 }}>
-        <EventIconBox>
-          <OasisGenericEvent />
-        </EventIconBox>
+        <EventIconBox />
         <EventContextBox>
           <EventText style={{ fontWeight: "bold" }}>Block Number</EventText>
           <EventText data-cy="transaction-block-number">{height}</EventText>

--- a/packages/client/src/ui/validators/ValidatorsListComponents.tsx
+++ b/packages/client/src/ui/validators/ValidatorsListComponents.tsx
@@ -64,16 +64,16 @@ export const ValidatorDetails = styled.div`
 
 export const ValidatorCapacityCircle = styled.div`
   border-radius: 50%;
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   margin-left: 26px;
   background: ${({ capacity }: { capacity: number }) => {
-    // Render a color based on the percent capacity
-    return capacity > 90
+    // Render a color based on the percent capacity:
+    return capacity > 99
       ? COLORS.ERROR
-      : capacity > 75
+      : capacity > 95
       ? "orange"
-      : capacity > 55
+      : capacity > 90
       ? COLORS.WARNING
       : COLORS.CHORUS_MINT;
   }};

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@cypress/webpack-preprocessor": "^4.1.1",
-    "cypress": "^3.8.1",
+    "cypress": "4.9.0",
     "prettier": "^1.19.1",
     "ts-loader": "^6.2.1",
     "tslint": "^5.20.1",

--- a/packages/cypress/src/integration/governance.spec.ts
+++ b/packages/cypress/src/integration/governance.spec.ts
@@ -1,4 +1,7 @@
+import { NETWORK_ADDRESS_DEFAULTS } from "@anthem/utils";
 import { SCREEN_SIZES, UTILS, APP_URL } from "../support/cypress-utils";
+
+const { CELO } = NETWORK_ADDRESS_DEFAULTS;
 
 /** ===========================================================================
  * Test the staking/ page
@@ -9,7 +12,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
   describe("Anthem supports governance for Celo networks", () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "celo");
+      // UTILS.loginWithAddress(type, "celo");
     });
 
     afterEach(() => {
@@ -17,7 +20,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
     });
 
     it("After logging in with an address the governance page is accessible", () => {
-      cy.visit(`${APP_URL}/governance`);
+      cy.visit(`${APP_URL}/celo/governance/${CELO.account}`);
       cy.contains("Governance");
       cy.contains("Proposals");
       cy.contains("Proposal Details");

--- a/packages/cypress/src/integration/governance.spec.ts
+++ b/packages/cypress/src/integration/governance.spec.ts
@@ -12,7 +12,6 @@ SCREEN_SIZES.forEach(({ size, type }) => {
   describe("Anthem supports governance for Celo networks", () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      // UTILS.loginWithAddress(type, "celo");
     });
 
     afterEach(() => {

--- a/packages/cypress/src/integration/login.spec.ts
+++ b/packages/cypress/src/integration/login.spec.ts
@@ -161,7 +161,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
 
       UTILS.checkForNetwork("cosmos");
       cy.contains("Transaction Detail");
-      cy.url().should("include", `txs/${COSMOS.tx_hash.toLowerCase()}`);
+      cy.url().should("include", `cosmos/txs/${COSMOS.tx_hash.toLowerCase()}`);
     });
 
     it("Celo transactions can be viewed by hash", () => {
@@ -177,7 +177,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
 
       UTILS.checkForNetwork("celo");
       cy.contains("Transaction Detail");
-      cy.url().should("include", `txs/${CELO.tx_hash.toLowerCase()}`);
+      cy.url().should("include", `celo/txs/${CELO.tx_hash.toLowerCase()}`);
     });
   });
 });

--- a/packages/cypress/src/integration/navigation.spec.ts
+++ b/packages/cypress/src/integration/navigation.spec.ts
@@ -52,16 +52,16 @@ SCREEN_SIZES.forEach(({ type, size }) => {
      */
     it("All navigation sub-routes in the Dashboard can be visited", () => {
       if (type.isDesktop()) {
-        cy.visit(`${APP_URL}/total`);
+        cy.visit(`${APP_URL}/cosmos/total`);
         cy.url().should("contain", "/total");
 
-        cy.visit(`${APP_URL}/available`);
+        cy.visit(`${APP_URL}/cosmos/available`);
         cy.url().should("contain", "/available");
 
-        cy.visit(`${APP_URL}/rewards`);
+        cy.visit(`${APP_URL}/cosmos/rewards`);
         cy.url().should("contain", "/rewards");
 
-        cy.visit(`${APP_URL}/staking`);
+        cy.visit(`${APP_URL}/cosmos/staking`);
         cy.url().should("contain", "/staking");
       }
     });

--- a/packages/cypress/src/integration/staking.spec.ts
+++ b/packages/cypress/src/integration/staking.spec.ts
@@ -12,7 +12,6 @@ SCREEN_SIZES.forEach(({ size, type }) => {
   describe("Anthem supports staking for Cosmos networks", () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      // UTILS.loginWithAddress(type, "cosmos");
     });
 
     afterEach(() => {
@@ -20,7 +19,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
     });
 
     it("After logging in with an address the staking page is accessible", () => {
-      cy.visit(`${APP_URL}/celo/delegate/${COSMOS.account}`);
+      cy.visit(`${APP_URL}/cosmos/delegate/${COSMOS.account}`);
       cy.contains("Staking");
       cy.contains("Withdraw Rewards");
       cy.contains("Withdraw Commissions");

--- a/packages/cypress/src/integration/staking.spec.ts
+++ b/packages/cypress/src/integration/staking.spec.ts
@@ -1,4 +1,7 @@
+import { NETWORK_ADDRESS_DEFAULTS } from "@anthem/utils";
 import { SCREEN_SIZES, UTILS, APP_URL } from "../support/cypress-utils";
+
+const { COSMOS } = NETWORK_ADDRESS_DEFAULTS;
 
 /** ===========================================================================
  * Test the staking/ page
@@ -9,7 +12,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
   describe("Anthem supports staking for Cosmos networks", () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
+      // UTILS.loginWithAddress(type, "cosmos");
     });
 
     afterEach(() => {
@@ -17,7 +20,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
     });
 
     it("After logging in with an address the staking page is accessible", () => {
-      cy.visit(`${APP_URL}/delegate`);
+      cy.visit(`${APP_URL}/celo/delegate/${COSMOS.account}`);
       cy.contains("Staking");
       cy.contains("Withdraw Rewards");
       cy.contains("Withdraw Commissions");

--- a/packages/cypress/src/plugins/index.js
+++ b/packages/cypress/src/plugins/index.js
@@ -20,12 +20,12 @@ module.exports = on => {
   // See the following:
   // - https://github.com/cypress-io/cypress/issues/350#issuecomment-503231128
   // - https://docs.cypress.io/api/plugins/browser-launch-api.html#Usage
-  on("before:browser:launch", (browser = {}, args) => {
+  on("before:browser:launch", (browser = {}, launchOptions) => {
     if (browser.name === "chrome") {
-      args.push("--disable-dev-shm-usage");
-      return args;
+      launchOptions.args.push("--disable-dev-shm-usage");
     }
-    return args;
+
+    return launchOptions;
   });
 
   // Webpack setup

--- a/packages/cypress/src/support/cypress-utils.ts
+++ b/packages/cypress/src/support/cypress-utils.ts
@@ -19,14 +19,14 @@ export const APP_URL = Cypress.env("HOST");
  * screen sizes.
  */
 export const SCREEN_SIZES = [
-  {
-    type: getScreenType(true),
-    size: "iphone-6+",
-  },
-  {
-    type: getScreenType(true),
-    size: "ipad-2",
-  },
+  // {
+  //   type: getScreenType(true),
+  //   size: "iphone-6+",
+  // },
+  // {
+  //   type: getScreenType(true),
+  //   size: "ipad-2",
+  // },
   {
     type: getScreenType(false),
     size: [1024, 768],

--- a/packages/cypress/src/support/cypress-utils.ts
+++ b/packages/cypress/src/support/cypress-utils.ts
@@ -19,14 +19,14 @@ export const APP_URL = Cypress.env("HOST");
  * screen sizes.
  */
 export const SCREEN_SIZES = [
-  // {
-  //   type: getScreenType(true),
-  //   size: "iphone-6+",
-  // },
-  // {
-  //   type: getScreenType(true),
-  //   size: "ipad-2",
-  // },
+  {
+    type: getScreenType(true),
+    size: "iphone-6+",
+  },
+  {
+    type: getScreenType(true),
+    size: "ipad-2",
+  },
   {
     type: getScreenType(false),
     size: [1024, 768],

--- a/packages/cypress/src/support/cypress-utils.ts
+++ b/packages/cypress/src/support/cypress-utils.ts
@@ -143,7 +143,7 @@ const loginWithAddress = (type: any, network: Network, useLedger = false) => {
    * Visit the app. Expect redirect to login and initiate the login
    * enter address flow.
    */
-  cy.visit(`${APP_URL}/total`);
+  cy.visit(`${APP_URL}/${network}/total`);
   cy.url().should("contain", "/login");
 
   /**

--- a/packages/utils/src/networks.ts
+++ b/packages/utils/src/networks.ts
@@ -146,7 +146,7 @@ const NETWORKS: NetworksMap = {
     denominationSize: 1e6,
   },
   OASIS: {
-    available: false,
+    available: true,
     name: "OASIS",
     denom: "AMBR", // For Amber testnet
     descriptor: "AMBR",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,6 +1675,32 @@
     date-fns "^1.27.2"
     figures "^1.7.0"
 
+"@cypress/request@2.88.5":
+  version "2.88.5"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
+  integrity sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 "@cypress/webpack-preprocessor@^4.1.1":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-4.1.3.tgz#d5fad767a304c16ec05ca08034827c601f1c9c0c"
@@ -4493,6 +4519,11 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/sinonjs__fake-timers@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
+  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
+
 "@types/sizzle@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
@@ -5195,11 +5226,6 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
-
 ansi-escapes@^3.0.0, ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -5583,7 +5609,12 @@ aproba@^2.0.0:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-arch@2.1.1, arch@^2.1.0:
+arch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.2.tgz#0c52bbe7344bb4fa260c443d2cbad9c00ff2f0bf"
+  integrity sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
+
+arch@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.1.tgz#8f5c2731aa35a30929221bb0640eed65175ec84e"
   integrity sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==
@@ -5860,14 +5891,7 @@ async@2.6.0:
   dependencies:
     lodash "^4.14.0"
 
-async@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
-  dependencies:
-    lodash "^4.17.10"
-
-async@>=0.6.0, async@^3.1.0:
+async@>=0.6.0, async@^3.1.0, async@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
@@ -6398,17 +6422,12 @@ block-stream@*:
     ts-node "^8.4.1"
     typescript "^3.6.4"
 
-bluebird@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-  integrity sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=
-
 bluebird@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
   integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
-bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@3.7.2, bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6910,14 +6929,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-cachedir@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.3.0.tgz#5e01928bf2d95b5edd94b0942188246740e0dbc4"
-  integrity sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==
-  dependencies:
-    os-homedir "^1.0.1"
-
-cachedir@^2.2.0:
+cachedir@2.3.0, cachedir@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
@@ -7348,11 +7360,6 @@ cli-progress@^3.4.0:
     colors "^1.1.2"
     string-width "^2.1.1"
 
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
-  integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
-
 cli-spinners@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
@@ -7362,6 +7369,16 @@ cli-spinners@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
+
+cli-table3@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
+  integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^2.1.1"
+  optionalDependencies:
+    colors "^1.1.2"
 
 cli-truncate@^0.2.1:
   version "0.2.1"
@@ -7694,15 +7711,15 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
-
 commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+commander@4.1.1, commander@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@5.0.0:
   version "5.0.0"
@@ -7718,11 +7735,6 @@ commander@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
-
-commander@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -7822,7 +7834,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@1.6.2, concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -8708,42 +8720,46 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^3.8.1:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.8.3.tgz#e921f5482f1cbe5814891c878f26e704bbffd8f4"
-  integrity sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==
+cypress@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.9.0.tgz#c188a3864ddf841c0fdc81a9e4eff5cf539cd1c1"
+  integrity sha512-qGxT5E0j21FPryzhb0OBjCdhoR/n1jXtumpFFSBPYWsaZZhNaBvc3XlBUDEZKkkXPsqUFYiyhWdHN/zo0t5FcA==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
+    "@cypress/request" "2.88.5"
     "@cypress/xvfb" "1.2.4"
+    "@types/sinonjs__fake-timers" "6.0.1"
     "@types/sizzle" "2.3.2"
-    arch "2.1.1"
-    bluebird "3.5.0"
-    cachedir "1.3.0"
+    arch "2.1.2"
+    bluebird "3.7.2"
+    cachedir "2.3.0"
     chalk "2.4.2"
     check-more-types "2.24.0"
-    commander "2.15.1"
+    cli-table3 "0.5.1"
+    commander "4.1.1"
     common-tags "1.8.0"
-    debug "3.2.6"
-    eventemitter2 "4.1.2"
-    execa "0.10.0"
+    debug "4.1.1"
+    eventemitter2 "6.4.2"
+    execa "1.0.0"
     executable "4.1.1"
-    extract-zip "1.6.7"
-    fs-extra "5.0.0"
-    getos "3.1.1"
-    is-ci "1.2.1"
-    is-installed-globally "0.1.0"
+    extract-zip "1.7.0"
+    fs-extra "8.1.0"
+    getos "3.2.1"
+    is-ci "2.0.0"
+    is-installed-globally "0.3.2"
     lazy-ass "1.6.0"
-    listr "0.12.0"
+    listr "0.14.3"
     lodash "4.17.15"
-    log-symbols "2.2.0"
-    minimist "1.2.0"
-    moment "2.24.0"
-    ramda "0.24.1"
-    request "2.88.0"
+    log-symbols "3.0.0"
+    minimist "1.2.5"
+    moment "2.26.0"
+    ospath "1.2.2"
+    pretty-bytes "5.3.0"
+    ramda "0.26.1"
     request-progress "3.0.0"
-    supports-color "5.5.0"
+    supports-color "7.1.0"
     tmp "0.1.0"
-    untildify "3.0.3"
+    untildify "4.0.0"
     url "0.11.0"
     yauzl "2.10.0"
 
@@ -10216,10 +10232,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter2@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-4.1.2.tgz#0e1a8477af821a6ef3995b311bf74c23a5247f15"
-  integrity sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=
+eventemitter2@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.2.tgz#f31f8b99d45245f0edbc5b00797830ff3b388970"
+  integrity sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw==
 
 eventemitter3@3.1.2, eventemitter3@^3.1.0:
   version "3.1.2"
@@ -10268,13 +10284,13 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
-execa@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
-  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
+execa@1.0.0, execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
   dependencies:
     cross-spawn "^6.0.0"
-    get-stream "^3.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -10301,19 +10317,6 @@ execa@^0.8.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
-  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
-  dependencies:
-    cross-spawn "^6.0.0"
-    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -10538,15 +10541,15 @@ extract-text-webpack-plugin@^3.0.2:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
-extract-zip@1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
-  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
+extract-zip@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
+  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
   dependencies:
-    concat-stream "1.6.2"
-    debug "2.6.9"
-    mkdirp "0.5.1"
-    yauzl "2.4.1"
+    concat-stream "^1.6.2"
+    debug "^2.6.9"
+    mkdirp "^0.5.4"
+    yauzl "^2.10.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -10692,13 +10695,6 @@ fbjs@^1.0.0:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
-
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
-  dependencies:
-    pend "~1.2.0"
 
 fd-slicer@~1.1.0:
   version "1.1.0"
@@ -11102,21 +11098,21 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
-  integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@7.0.1, fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@8.1.0, fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -11135,15 +11131,6 @@ fs-extra@^4.0.2:
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -11346,12 +11333,12 @@ getenv@^0.7.0:
   resolved "https://registry.yarnpkg.com/getenv/-/getenv-0.7.0.tgz#39b91838707e2086fd1cf6ef8777d1c93e14649e"
   integrity sha1-ObkYOHB+IIb9HPbvh3fRyT4UZJ4=
 
-getos@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.1.tgz#967a813cceafee0156b0483f7cffa5b3eff029c5"
-  integrity sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==
+getos@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/getos/-/getos-3.2.1.tgz#0134d1f4e00eb46144c5a9c0ac4dc087cbb27dc5"
+  integrity sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==
   dependencies:
-    async "2.6.1"
+    async "^3.2.0"
 
 getos@^3.1.1:
   version "3.1.5"
@@ -11501,6 +11488,13 @@ global-dirs@^0.1.0:
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
   dependencies:
     ini "^1.3.4"
+
+global-dirs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
+  integrity sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==
+  dependencies:
+    ini "^1.3.5"
 
 global-modules@2.0.0:
   version "2.0.0"
@@ -11929,7 +11923,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0, har-validator@~5.1.3:
+har-validator@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -12851,19 +12845,19 @@ is-callable@^1.1.4, is-callable@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
 
-is-ci@1.2.1, is-ci@^1.0.10:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
-  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
-  dependencies:
-    ci-info "^1.5.0"
-
-is-ci@^2.0.0:
+is-ci@2.0.0, is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
 
 is-color-stop@^1.0.0:
   version "1.1.0"
@@ -13002,7 +12996,15 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
-is-installed-globally@0.1.0, is-installed-globally@^0.1.0:
+is-installed-globally@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
+  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+  dependencies:
+    global-dirs "^2.0.1"
+    is-path-inside "^3.0.1"
+
+is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
   integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
@@ -14319,30 +14321,6 @@ listr-update-renderer@0.5.0, listr-update-renderer@^0.5.0:
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
-listr-update-renderer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
-  integrity sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-listr-verbose-renderer@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
-  integrity sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
 listr-verbose-renderer@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
@@ -14352,28 +14330,6 @@ listr-verbose-renderer@^0.5.0:
     cli-cursor "^2.1.0"
     date-fns "^1.27.2"
     figures "^2.0.0"
-
-listr@0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
-  integrity sha1-a84sD1YD+klYDqF81qAMwOX6RRo=
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    figures "^1.7.0"
-    indent-string "^2.1.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.2.0"
-    listr-verbose-renderer "^0.4.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    ora "^0.2.3"
-    p-map "^1.1.1"
-    rxjs "^5.0.0-beta.11"
-    stream-to-observable "^0.1.0"
-    strip-ansi "^3.0.1"
 
 listr@0.14.3:
   version "0.14.3"
@@ -14802,14 +14758,6 @@ log-update@4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
-
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
-  integrity sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=
-  dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -15356,22 +15304,12 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
 
-minimist@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@1.2.5, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -15456,17 +15394,17 @@ mkdirp@*, mkdirp@1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 mkdirp@0.5.4, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
   integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
+  dependencies:
+    minimist "^1.2.5"
+
+mkdirp@^0.5.4:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
@@ -15538,7 +15476,12 @@ moment-timezone@^0.5.28:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.24.0, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.24.0:
+moment@2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
+  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+
+"moment@>= 2.9.0", moment@>=2.14.0, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -16535,16 +16478,6 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
-ora@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
-  integrity sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=
-  dependencies:
-    chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
-
 ora@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
@@ -16619,6 +16552,11 @@ osenv@0, osenv@^0.1.4, osenv@^0.1.5:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+ospath@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
+  integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
 
 p-all@^2.0.0, p-all@^2.1.0:
   version "2.1.0"
@@ -18320,7 +18258,7 @@ prettier@1.19.1, prettier@^1.18.2, prettier@^1.19.1, prettier@^1.7.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-bytes@^5.1.0:
+pretty-bytes@5.3.0, pretty-bytes@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
   integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
@@ -18529,7 +18467,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24, psl@^1.1.28:
+psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -18594,7 +18532,7 @@ punycode@2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
   integrity sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=
 
-punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
+punycode@^1.2.4, punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -18690,12 +18628,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-ramda@0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
-  integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
-
-ramda@^0.26.1:
+ramda@0.26.1, ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
@@ -19584,32 +19517,6 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@2.88.0:
-  version "2.88.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.0"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.4.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 request@2.88.2, "request@>= 2.52.0", request@^2.79.0, request@^2.87.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
@@ -19910,13 +19817,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
-
-rxjs@^5.0.0-beta.11:
-  version "5.5.12"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
-  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
-  dependencies:
-    symbol-observable "1.0.1"
 
 rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3:
   version "6.5.4"
@@ -20864,11 +20764,6 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
-stream-to-observable@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
-  integrity sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=
-
 streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
@@ -21143,13 +21038,6 @@ subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16:
     symbol-observable "^1.0.4"
     ws "^5.2.0"
 
-supports-color@5.5.0, supports-color@^5.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
@@ -21163,6 +21051,13 @@ supports-color@6.1.0, supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@7.1.0, supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-color@^0.2.0:
   version "0.2.0"
@@ -21188,12 +21083,12 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+supports-color@^5.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
-    has-flag "^4.0.0"
+    has-flag "^3.0.0"
 
 supports-hyperlinks@^1.0.1:
   version "1.0.1"
@@ -21281,11 +21176,6 @@ swipyjs@^0.0.5:
   integrity sha512-+eTxv+TkOP6wSJ0lljieFkhJxqapqRtGHtchKieZwgECTf00HD2IJ1qpHOFSqCnaG9QPk2tTmFy5PaES0ycfTQ==
   dependencies:
     laravel-mix "^3.0.0"
-
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
@@ -21718,14 +21608,6 @@ tough-cookie@^3.0.1:
     ip-regex "^2.1.0"
     psl "^1.1.28"
     punycode "^2.1.1"
-
-tough-cookie@~2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
-  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
-  dependencies:
-    psl "^1.1.24"
-    punycode "^1.4.1"
 
 tr46@^1.0.1:
   version "1.0.1"
@@ -22289,10 +22171,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-untildify@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
-  integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
+untildify@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -24247,20 +24129,13 @@ yarn@^1.21.1, yarn@^1.22.4:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
   integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
 
-yauzl@2.10.0, yauzl@^2.4.2:
+yauzl@2.10.0, yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
-  dependencies:
-    fd-slicer "~1.0.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
**This PR:**

* Refactoring Anthem routing/url patterns.

**Notes:**

* An issue was found when working on the Oasis integration where `txs/` detail paths include no network information and it's less reliable to derive networks from transaction hashes. In addition, all Anthem pages currently have a built-in assume an address (and also network) is currently connected. This result in `txs/` pages not working as deep links, unless a user had already loaded the correct network address in Anthem.
* The solution which is mostly implemented by this PR is to add a `/:network` prefix to all main app routes to embed the current network information in the url. In addition, this PR includes the `address=` param in other routes, such as governance and staking, so these can also be more effective deep links.
* Another followup step is to adjust the Anthem logic to allow the app to load without a connected address, e.g. so `txs/` pages can be viewed directly from a link without the need to connect an address.

**Todo:**

* Create the `NetworkSummary` UI to allow Anthem to work in a state where no address is connected.