### PR TITLE
Add capacity tooltip for Celo validators list

### DIFF
--- a/packages/client/src/ui/validators/CeloValidators.tsx
+++ b/packages/client/src/ui/validators/CeloValidators.tsx
@@ -3,7 +3,15 @@ import {
   ICeloValidatorGroup,
   IQuery,
 } from "@anthem/utils";
-import { Card, Collapse, H5, H6, Icon } from "@blueprintjs/core";
+import {
+  Card,
+  Collapse,
+  H5,
+  H6,
+  Icon,
+  Position,
+  Tooltip,
+} from "@blueprintjs/core";
 import { CopyIcon, NetworkLogoIcon } from "assets/images";
 import { COLORS } from "constants/colors";
 import {
@@ -255,10 +263,18 @@ class CeloValidatorsListPage extends React.Component<IProps, IState> {
                               <RowItem width={150}>
                                 <Text>{votingPowerFraction}%</Text>
                               </RowItem>
-                              <RowItem width={150}>
-                                <ValidatorCapacityCircle
-                                  capacity={votingCapacityPercentage}
-                                />
+                              <RowItem width={150} style={{ paddingLeft: 26 }}>
+                                <Tooltip
+                                  usePortal={false}
+                                  position={Position.TOP}
+                                  content={`Available Voting Capacity: ${votingCapacityPercentage.toFixed(
+                                    2,
+                                  )}%`}
+                                >
+                                  <ValidatorCapacityCircle
+                                    capacity={votingCapacityPercentage}
+                                  />
+                                </Tooltip>
                               </RowItem>
                               <RowItem>
                                 <Icon

--- a/packages/client/src/ui/validators/ValidatorsListComponents.tsx
+++ b/packages/client/src/ui/validators/ValidatorsListComponents.tsx
@@ -67,7 +67,6 @@ export const ValidatorCapacityCircle = styled.div`
   border-radius: 50%;
   width: 14px;
   height: 14px;
-  margin-left: 26px;
   background: ${({ capacity }: { capacity: number }) => {
     // Render a color based on the percent capacity:
     return capacity < 1


### PR DESCRIPTION
**This PR:**

* Add capacity tooltip for Celo validators list.
* Incidentally I realized that Blueprint appears to invert the theme colors for tooltips/popovers (???), i.e. a tooltip on a normal theme is dark and vice versa. This is why some of the themes for tooltips/popovers were inverted...