### PR TITLE
derived the network address to fix the invalid url

### DIFF
--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -4,6 +4,7 @@ import {
   CeloTransactionsDocument,
   CosmosAccountBalancesDocument,
   CosmosTransactionsDocument,
+  deriveNetworkFromAddress,
   validatorAddressToOperatorAddress,
   wait,
 } from "@anthem/utils";
@@ -76,7 +77,19 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
       // Try to initialize the transactions page from the url
       const paramsPage = Number(params.page);
       const page = !isNaN(paramsPage) ? paramsPage : 1;
-      const network = initializeNetwork(window.location.pathname, address);
+      let network = initializeNetwork(window.location.pathname, address);
+
+      const derivedNetwork = deriveNetworkFromAddress(address);
+
+      const onDifferentNetwork = network.name !== derivedNetwork.name;
+
+      // Redirecting to correct location if the network does not match with that of the address
+      if (onDifferentNetwork) {
+        network = derivedNetwork;
+        deps.router.replace({
+          pathname: `/${derivedNetwork.name.toLowerCase()}/total`,
+        });
+      }
 
       return Actions.initializeAppSuccess({
         address,

--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -79,16 +79,18 @@ const appInitializationEpic: EpicSignature = (action$, state$, deps) => {
       const page = !isNaN(paramsPage) ? paramsPage : 1;
       let network = initializeNetwork(window.location.pathname, address);
 
-      const derivedNetwork = deriveNetworkFromAddress(address);
+      if (address) {
+        const derivedNetwork = deriveNetworkFromAddress(address);
 
-      const onDifferentNetwork = network.name !== derivedNetwork.name;
+        const onDifferentNetwork = network.name !== derivedNetwork.name;
 
-      // Redirecting to correct location if the network does not match with that of the address
-      if (onDifferentNetwork) {
-        network = derivedNetwork;
-        deps.router.replace({
-          pathname: `/${derivedNetwork.name.toLowerCase()}/total`,
-        });
+        // Redirecting to correct location if the network does not match with that of the address
+        if (onDifferentNetwork) {
+          network = derivedNetwork;
+          deps.router.replace({
+            pathname: `/${derivedNetwork.name.toLowerCase()}/total`,
+          });
+        }
       }
 
       return Actions.initializeAppSuccess({

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -277,14 +277,12 @@ export const getPortfolioTypeFromUrl = (
  * Initialize the network when the app launches.
  */
 export const initializeNetwork = (
-  url: string,
+  _url: string,
   address: string,
 ): NetworkDefinition => {
-  const network = url.split("/")[1];
-  const networkDefinition = NETWORKS[network.toUpperCase()];
-  if (networkDefinition) {
-    return networkDefinition;
-  } else if (address) {
+  // Due to a spammy error (https://sentry.io/organizations/chorus-one/issues/1638505828/events/e03550f4e2514fa9990331a095442149/?project=1531694)
+  // we are now only deriving the network from the address
+  if (address) {
     const derivedNetwork = deriveNetworkFromAddress(address);
     return derivedNetwork;
   } else {

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -277,12 +277,14 @@ export const getPortfolioTypeFromUrl = (
  * Initialize the network when the app launches.
  */
 export const initializeNetwork = (
-  _: string,
+  url: string,
   address: string,
 ): NetworkDefinition => {
-  // Due to a spammy error (https://sentry.io/organizations/chorus-one/issues/1638505828/events/e03550f4e2514fa9990331a095442149/?project=1531694)
-  // we are now only deriving the network from the address
-  if (address) {
+  const network = url.split("/")[1];
+  const networkDefinition = NETWORKS[network.toUpperCase()];
+  if (networkDefinition) {
+    return networkDefinition;
+  } else if (address) {
     const derivedNetwork = deriveNetworkFromAddress(address);
     return derivedNetwork;
   } else {

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -277,7 +277,7 @@ export const getPortfolioTypeFromUrl = (
  * Initialize the network when the app launches.
  */
 export const initializeNetwork = (
-  _url: string,
+  _: string,
   address: string,
 ): NetworkDefinition => {
   // Due to a spammy error (https://sentry.io/organizations/chorus-one/issues/1638505828/events/e03550f4e2514fa9990331a095442149/?project=1531694)


### PR DESCRIPTION
When the user hits <URL>/cosmos/<oasisaddress>, the server gets confused with the network and the invalid address.
So we are now deriving the network from the address, so that even if the network name is not matching with the address it still resolves to the correct network i.e., Oasis in this case.