### PR TITLE
conditional rewards tab for oasis

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -43,7 +43,7 @@
     "apollo-client": "^2.6.3",
     "apollo-link-http": "^1.5.15",
     "apollo-link-schema": "^1.2.3",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "babel-loader": "8.0.5",
     "bech32": "^1.1.3",
     "bignumber.js": "^9.0.0",

--- a/packages/client/src/tools/client-utils.ts
+++ b/packages/client/src/tools/client-utils.ts
@@ -199,6 +199,8 @@ export const getChartTabsForNetwork = (network: NetworkDefinition) => {
 
       if (key === "STAKING" && network.name === "CELO") {
         continue;
+      } else if (key === "REWARDS" && network.name === "OASIS") {
+        continue;
       } else {
         result[key] = value;
       }

--- a/packages/client/src/ui/pages/DashboardPage.tsx
+++ b/packages/client/src/ui/pages/DashboardPage.tsx
@@ -165,11 +165,10 @@ class DashboardPage extends React.Component<IProps> {
     // For OASIS - Conditionally rendering the "REWARDS" tab based on data
     // i.e., Don't render the tab if sum of all the rewards data is 0
     if (oasisAccountHistory) {
-      let sumOfRewards = 0;
-
-      oasisAccountHistory.forEach(account => {
-        sumOfRewards = sumOfRewards + (parseInt(account.rewards) || 0);
-      });
+      const sumOfRewards = oasisAccountHistory.reduce(
+        (prev, current) => prev + (parseInt(current.rewards) || 0),
+        0,
+      );
 
       if (sumOfRewards > 0) {
         tabs.REWARDS = "REWARDS";

--- a/packages/client/src/ui/pages/DashboardPage.tsx
+++ b/packages/client/src/ui/pages/DashboardPage.tsx
@@ -38,6 +38,11 @@ import PortfolioSwitchContainer from "ui/portfolio/PortfolioSwitchContainer";
 import { View } from "ui/SharedComponents";
 import Toast from "ui/Toast";
 import TransactionSwitchContainer from "ui/transactions/TransactionSwitchContainer";
+import {
+  OasisAccountHistoryProps,
+  withGraphQLVariables,
+  withOasisAccountHistory,
+} from "../../graphql/queries";
 
 /** ===========================================================================
  * React Component
@@ -144,11 +149,32 @@ class DashboardPage extends React.Component<IProps> {
   }
 
   renderDashboardNavigationLinks = () => {
-    const { address, ledger, history, settings, location } = this.props;
+    const {
+      address,
+      ledger,
+      history,
+      settings,
+      location,
+      oasisAccountHistory: { oasisAccountHistory },
+    } = this.props;
     const { network } = ledger;
     const { pathname } = location;
 
     const tabs = getChartTabsForNetwork(network);
+
+    // For OASIS - Conditionally rendering the "REWARDS" tab based on data
+    // i.e., Don't render the tab if sum of all the rewards data is 0
+    if (oasisAccountHistory) {
+      let sumOfRewards = 0;
+
+      oasisAccountHistory.forEach(account => {
+        sumOfRewards = sumOfRewards + (parseInt(account.rewards) || 0);
+      });
+
+      if (sumOfRewards > 0) {
+        tabs.REWARDS = "REWARDS";
+      }
+    }
 
     if (settings.isDesktop) {
       return (
@@ -448,7 +474,11 @@ type ConnectProps = ReturnType<typeof mapStateToProps> & typeof dispatchProps;
 
 interface ComponentProps {}
 
-interface IProps extends ComponentProps, ConnectProps, RouteComponentProps {}
+interface IProps
+  extends ComponentProps,
+    ConnectProps,
+    RouteComponentProps,
+    OasisAccountHistoryProps {}
 
 /** ===========================================================================
  * Export
@@ -458,4 +488,6 @@ interface IProps extends ComponentProps, ConnectProps, RouteComponentProps {}
 export default composeWithProps<ComponentProps>(
   withProps,
   withRouter,
+  withGraphQLVariables,
+  withOasisAccountHistory,
 )(DashboardPage);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,7 +30,7 @@
     "@anthem/utils": "^0.0.1",
     "a-simple-cache": "^2.0.1",
     "apollo-server-express": "^2.7.2",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "chalk": "^2.4.2",
     "contentful": "^7.15.0",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6438,6 +6438,13 @@ axios@^0.20.0:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"


### PR DESCRIPTION
For Oasis network, rewards tab was there even though there was no data for it.
Now by default, the rewards tab is not there. It appears only if there is some data for it.