### PR TITLE
Cosmos unsupported

### DIFF
--- a/packages/client/src/ui/NetworkSelect.tsx
+++ b/packages/client/src/ui/NetworkSelect.tsx
@@ -24,11 +24,21 @@ class NetworkSelectComponent extends React.Component<IProps, {}> {
   render(): JSX.Element {
     const enableThemedStyles = !this.onLandingPage();
     const color = enableThemedStyles ? undefined : COLORS.DARK_TITLE;
+
+    const filteredAvailableNetworks = () => {
+      return Object.values(AVAILABLE_NETWORKS).filter(
+        ({ name }) =>
+          name !== "COSMOS" &&
+          name !== "KAVA" &&
+          name !== "TERRA" &&
+          name !== "POLKADOT",
+      );
+    };
     return (
-      <View>
+      <StyledView>
         <p style={{ color }}>Choose a network to connect to:</p>
         <NetworkGrid>
-          {Object.values(AVAILABLE_NETWORKS).map(network => {
+          {filteredAvailableNetworks().map(network => {
             return (
               <NetworkSelect
                 enableThemedStyles
@@ -41,7 +51,7 @@ class NetworkSelectComponent extends React.Component<IProps, {}> {
         </NetworkGrid>
 
         <MyLedgerDoesntWork />
-      </View>
+      </StyledView>
     );
   }
 
@@ -80,9 +90,16 @@ class NetworkSelectComponent extends React.Component<IProps, {}> {
   };
 }
 
+const StyledView = styled(View)`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
 const MyLedgerDoesntWorkLink = styled.div`
   color: #106ba3;
   padding-top: 22px;
+  margin-top: auto;
   font-size: 18px;
   text-align: center;
   cursor: pointer;

--- a/packages/client/src/ui/NotificationsBanner.tsx
+++ b/packages/client/src/ui/NotificationsBanner.tsx
@@ -4,9 +4,7 @@ import Modules, { ReduxStoreState } from "modules/root";
 import { i18nSelector } from "modules/settings/selectors";
 import React from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { capitalizeString } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 
 /** ===========================================================================
@@ -32,10 +30,6 @@ class NotificationsBanner extends React.Component<IProps> {
       return null;
     }
 
-    if (!this.props.address) {
-      return null;
-    }
-
     return (
       <Banner className="notifications-banner">
         {this.getBannerTextForNetwork()}
@@ -51,22 +45,12 @@ class NotificationsBanner extends React.Component<IProps> {
       case "COSMOS":
         return (
           <BannerText>
-            <b>
-              <span role="img" aria-label="warning-emoji">
-                ⚠️
-              </span>{" "}
-              BETA:
-            </b>{" "}
-            Anthem provides data for the {capitalizeString(name)} network but is
-            currently in a beta release. You may experience data integrity
-            issues.{" "}
-            <Link
-              to="/help"
-              onClick={this.props.displayDataIntegrityHelpLabel}
-              style={{ color: COLORS.WHITE, textDecoration: "underline" }}
-            >
-              Learn More.
-            </Link>
+            <span role="img" aria-label="warning-emoji">
+              ⚠️
+            </span>{" "}
+            After the cosmoshub-4 upgrade, Anthem unfortunately no longer
+            supports Cosmos. Reach out if you have questions or if you want to
+            help maintain historical data for the Cosmos Hub.
           </BannerText>
         );
       case "TERRA":

--- a/packages/client/src/ui/SideMenu.tsx
+++ b/packages/client/src/ui/SideMenu.tsx
@@ -11,11 +11,7 @@ import { IconNames } from "@blueprintjs/icons";
 import { ChorusLogo } from "assets/icons";
 import { NetworkLogoIcon } from "assets/images";
 import { COLORS } from "constants/colors";
-import {
-  ValidatorsProps,
-  withGraphQLVariables,
-  withValidators,
-} from "graphql/queries";
+import { ValidatorsProps, withGraphQLVariables } from "graphql/queries";
 import Modules, { ReduxStoreState } from "modules/root";
 import { i18nSelector } from "modules/settings/selectors";
 import React from "react";
@@ -614,6 +610,5 @@ interface IProps
 export default composeWithProps<ComponentProps>(
   withProps,
   withGraphQLVariables,
-  withValidators,
   withRouter,
 )(SideMenuComponent);

--- a/packages/client/src/ui/balances/BalancesSwitchContainer.tsx
+++ b/packages/client/src/ui/balances/BalancesSwitchContainer.tsx
@@ -84,7 +84,7 @@ class BalancesSwitchContainer extends React.Component<IProps, IState> {
       case "TERRA":
       case "KAVA":
       case "COSMOS":
-        return <CosmosBalances />;
+        return null;
       case "OASIS":
         return <OasisBalances />;
       case "CELO":

--- a/packages/client/src/ui/balances/BalancesSwitchContainer.tsx
+++ b/packages/client/src/ui/balances/BalancesSwitchContainer.tsx
@@ -13,11 +13,7 @@ import { RouteComponentProps } from "react-router";
 import { capitalizeString } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import { PanelMessageText } from "ui/SharedComponents";
-import {
-  CeloBalances,
-  CosmosBalances,
-  OasisBalances,
-} from "./BalancesComponents";
+import { CeloBalances, OasisBalances } from "./BalancesComponents";
 
 /** ===========================================================================
  * Types & Config

--- a/packages/client/src/ui/pages/NetworkSummaryPage.tsx
+++ b/packages/client/src/ui/pages/NetworkSummaryPage.tsx
@@ -37,6 +37,16 @@ class NetworkSummaryPage extends React.Component<IProps> {
     const { tString } = i18n;
     const { letter } = settings.fiatCurrency;
 
+    const filterUnsupportedNetworks = (summaries: INetworkSummary[]) => {
+      return summaries.filter(
+        ({ name }) =>
+          name !== "TERRA" &&
+          name !== "COSMOS" &&
+          name !== "KAVA" &&
+          name !== "POLKADOT",
+      );
+    };
+
     return (
       <PageContainer>
         <PageAddressBar pageTitle="Network Summaries" />
@@ -92,104 +102,102 @@ class NetworkSummaryPage extends React.Component<IProps> {
                     </ItemHeader>
                     <ItemHeader />
                   </HeaderRow>
-                  {summaries
-                    .filter(({ name }) => name !== "TERRA")
-                    .map(summary => {
-                      const name = summary.name as NETWORK_NAME;
+                  {filterUnsupportedNetworks(summaries).map(summary => {
+                    const name = summary.name as NETWORK_NAME;
 
-                      const {
-                        inflation,
-                        tokenPrice,
-                        lastDayChange,
-                        expectedReward,
-                        supportsLedger,
-                        marketCapitalization,
-                      } = summary;
+                    const {
+                      inflation,
+                      tokenPrice,
+                      lastDayChange,
+                      expectedReward,
+                      supportsLedger,
+                      marketCapitalization,
+                    } = summary;
 
-                      return (
-                        <Row key={name}>
-                          <Item style={{ width: 45 }}>
-                            <NetworkLogoIcon network={name} />
-                          </Item>
-                          <Item>
-                            <Text>
-                              {name ? <b>{capitalizeString(name)}</b> : "n/a"}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {tokenPrice ? (
-                                <span>
-                                  {letter}
-                                  {formatCurrencyAmount(tokenPrice, 2)}
-                                </span>
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {lastDayChange ? (
-                                <PercentChangeText value={lastDayChange} />
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {marketCapitalization ? (
-                                <span>
-                                  {letter}
-                                  {formatCurrencyAmount(marketCapitalization)}
-                                </span>
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {expectedReward ? (
-                                <span>{expectedReward.toFixed(2)}%</span>
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {inflation ? (
-                                <span>{inflation.toFixed(2)}%</span>
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            <Text>
-                              {expectedReward && inflation ? (
-                                <span>
-                                  {(expectedReward - inflation).toFixed(2)}%
-                                </span>
-                              ) : (
-                                "n/a"
-                              )}
-                            </Text>
-                          </Item>
-                          <Item>
-                            {supportsLedger && (
-                              <Button
-                                onClick={() => this.handleConnectNetwork(name)}
-                              >
-                                Connect
-                              </Button>
+                    return (
+                      <Row key={name}>
+                        <Item style={{ width: 45 }}>
+                          <NetworkLogoIcon network={name} />
+                        </Item>
+                        <Item>
+                          <Text>
+                            {name ? <b>{capitalizeString(name)}</b> : "n/a"}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {tokenPrice ? (
+                              <span>
+                                {letter}
+                                {formatCurrencyAmount(tokenPrice, 2)}
+                              </span>
+                            ) : (
+                              "n/a"
                             )}
-                          </Item>
-                        </Row>
-                      );
-                    })}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {lastDayChange ? (
+                              <PercentChangeText value={lastDayChange} />
+                            ) : (
+                              "n/a"
+                            )}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {marketCapitalization ? (
+                              <span>
+                                {letter}
+                                {formatCurrencyAmount(marketCapitalization)}
+                              </span>
+                            ) : (
+                              "n/a"
+                            )}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {expectedReward ? (
+                              <span>{expectedReward.toFixed(2)}%</span>
+                            ) : (
+                              "n/a"
+                            )}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {inflation ? (
+                              <span>{inflation.toFixed(2)}%</span>
+                            ) : (
+                              "n/a"
+                            )}
+                          </Text>
+                        </Item>
+                        <Item>
+                          <Text>
+                            {expectedReward && inflation ? (
+                              <span>
+                                {(expectedReward - inflation).toFixed(2)}%
+                              </span>
+                            ) : (
+                              "n/a"
+                            )}
+                          </Text>
+                        </Item>
+                        <Item>
+                          {supportsLedger && (
+                            <Button
+                              onClick={() => this.handleConnectNetwork(name)}
+                            >
+                              Connect
+                            </Button>
+                          )}
+                        </Item>
+                      </Row>
+                    );
+                  })}
                 </Card>
               </Scrollable>
             );

--- a/packages/client/src/ui/portfolio/PortfolioSwitchContainer.tsx
+++ b/packages/client/src/ui/portfolio/PortfolioSwitchContainer.tsx
@@ -9,7 +9,6 @@ import { capitalizeString } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import { PanelMessageText } from "ui/SharedComponents";
 import CeloPortfolio from "./CeloPortfolio";
-import CosmosPortfolio from "./CosmosPortfolio";
 import OasisPortfolio from "./OasisPortfolio";
 
 /** ===========================================================================

--- a/packages/client/src/ui/portfolio/PortfolioSwitchContainer.tsx
+++ b/packages/client/src/ui/portfolio/PortfolioSwitchContainer.tsx
@@ -76,12 +76,7 @@ class PortfolioSwitchContainer extends React.Component<IProps, IState> {
     switch (network.name) {
       case "TERRA":
       case "COSMOS":
-        return (
-          <CosmosPortfolio
-            fullSize={this.props.fullSize}
-            downloadDataToFile={this.downloadDataToFile}
-          />
-        );
+        return null;
       case "OASIS":
         return (
           <OasisPortfolio

--- a/packages/client/src/ui/transactions/TransactionSwitchContainer.tsx
+++ b/packages/client/src/ui/transactions/TransactionSwitchContainer.tsx
@@ -8,7 +8,6 @@ import { capitalizeString } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import { PanelMessageText } from "ui/SharedComponents";
 import CeloTransactionContainer from "ui/transactions/CeloTransactionContainer";
-import CosmosTransactionContainer from "ui/transactions/CosmosTransactionContainer";
 import OasisTransactionContainer from "ui/transactions/OasisTransactionContainer";
 
 /** ===========================================================================

--- a/packages/client/src/ui/transactions/TransactionSwitchContainer.tsx
+++ b/packages/client/src/ui/transactions/TransactionSwitchContainer.tsx
@@ -76,7 +76,7 @@ class TransactionSwitchContainer extends React.Component<IProps, IState> {
     switch (network.name) {
       case "TERRA":
       case "COSMOS":
-        return <CosmosTransactionContainer />;
+        return null;
       case "OASIS":
         return <OasisTransactionContainer />;
       case "CELO":

--- a/packages/client/src/ui/validators/ValidatorsSwitchContainer.tsx
+++ b/packages/client/src/ui/validators/ValidatorsSwitchContainer.tsx
@@ -76,7 +76,7 @@ class ValidatorsSwitchContainer extends React.Component<IProps, IState> {
     switch (network.name) {
       case "TERRA":
       case "COSMOS":
-        return <CosmosValidators />;
+        return null;
       case "OASIS":
         return <OasisValidators />;
       case "CELO":

--- a/packages/client/src/ui/validators/ValidatorsSwitchContainer.tsx
+++ b/packages/client/src/ui/validators/ValidatorsSwitchContainer.tsx
@@ -8,7 +8,6 @@ import { capitalizeString } from "tools/client-utils";
 import { composeWithProps } from "tools/context-utils";
 import PolkadotPage from "ui/pages/PolkadotPage";
 import { PanelMessageText } from "ui/SharedComponents";
-import CosmosValidators from "ui/validators/CosmosValidators";
 import { OasisValidators } from "ui/validators/OasisValidators";
 import CeloValidators from "./CeloValidators";
 

--- a/packages/client/src/ui/workflows/CeloTransactionWorkflows.tsx
+++ b/packages/client/src/ui/workflows/CeloTransactionWorkflows.tsx
@@ -1108,7 +1108,7 @@ class CeloTransactionForm extends React.Component<IProps, IState> {
         active={modifiers.active}
         key={validator.group}
         text={validator.name}
-        data-cy={`${validator.name}-delegation-option`}
+        data-cy={`${validator.name.split(" ").join("")}-delegation-option`}
       />
     );
   };

--- a/packages/client/src/ui/workflows/LedgerDialogWorkflow.tsx
+++ b/packages/client/src/ui/workflows/LedgerDialogWorkflow.tsx
@@ -415,6 +415,9 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
               <AddressSubtitle>
                 Don't have an address on hand? Choose one below to explore a
                 network you're interested in.
+                <p className="note">
+                  NOTE: Please do NOT send funds to these addresses.
+                </p>
               </AddressSubtitle>
               <Column
                 style={{ marginTop: 6, maxHeight: 85, overflowY: "scroll" }}
@@ -679,7 +682,11 @@ const BackArrow = () => (
   />
 );
 
-const AddressSubtitle = styled.b``;
+const AddressSubtitle = styled.b`
+  .note {
+    margin: 12px 0;
+  }
+`;
 
 const ClearAllLink = styled.p`
   width: 150px;

--- a/packages/client/src/ui/workflows/LedgerDialogWorkflow.tsx
+++ b/packages/client/src/ui/workflows/LedgerDialogWorkflow.tsx
@@ -425,18 +425,18 @@ class LedgerDialogComponents extends React.PureComponent<IProps, IState> {
                 <Link
                   replace
                   style={{ marginTop: 2, marginBottom: 2 }}
-                  to={`/cosmos/${activeChartTab.toLowerCase()}?address=cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd`}
+                  to={`/celo/${activeChartTab.toLowerCase()}?address=0x0223cdb245a1ece59770ed20e852dd2b5b4e108a`}
                 >
                   <Row style={{ justifyContent: "flex-start" }}>
                     <NetworkLogoIcon
-                      network="COSMOS"
+                      network="CELO"
                       styles={{ width: 22, height: 22, marginRight: 6 }}
                     />
                     <View>
-                      <NetworkLabel>COSMOS</NetworkLabel>
+                      <NetworkLabel>CELO</NetworkLabel>
                       <RecentAddress>
                         {formatAddressString(
-                          "cosmos15urq2dtp9qce4fyc85m6upwm9xul3049um7trd",
+                          "0x0223cdb245a1ece59770ed20e852dd2b5b4e108a",
                           !this.props.settings.isDesktop,
                           25,
                         )}

--- a/packages/cypress/src/integration/ledger.spec.ts
+++ b/packages/cypress/src/integration/ledger.spec.ts
@@ -7,7 +7,7 @@ import { UTILS, getScreenType } from "../support/cypress-utils";
 
 describe("Test Ledger Transactions", () => {
   beforeEach(() => {
-    UTILS.loginWithAddress(getScreenType(), "cosmos", true);
+    UTILS.loginWithAddress(getScreenType(), "celo", true);
   });
 
   afterEach(() => {
@@ -17,10 +17,10 @@ describe("Test Ledger Transactions", () => {
   // Error with no value:
   it("The delegation transaction workflow can be completed", () => {
     UTILS.findAndClick("stake-button");
-    UTILS.findAndClick(
-      "validator-cosmosvaloper15urq2dtp9qce4fyc85m6upwm9xul3049e02707",
-    );
+    UTILS.findAndClick("validator-0x81cef0668e15639d0b101bdc3067699309d73bed");
     UTILS.findAndClick("delegate-button");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.shouldMatchText(
       "amount-transaction-error",
@@ -29,7 +29,7 @@ describe("Test Ledger Transactions", () => {
 
     // Open the validator menu and selector a validator
     UTILS.findAndClick("validator-composition-select-menu");
-    UTILS.findAndClick("Cosmostation-delegation-option");
+    UTILS.findAndClick("ChorusOne-delegation-option");
 
     // Error with very large value added:
     UTILS.typeText("transaction-amount-input", "500000000000");
@@ -40,63 +40,43 @@ describe("Test Ledger Transactions", () => {
     );
 
     UTILS.findAndClick("transaction-delegate-all-toggle");
-    UTILS.findAndClick("toggle-custom-gas-settings");
-
-    UTILS.typeText("custom-gas-price-input", "0.05");
-    UTILS.typeText("custom-gas-amount-input", "200000");
 
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     cy.wait(5000);
-    UTILS.findAndClick("transaction-submit-button");
-    cy.wait(5000);
+
     UTILS.findAndClick("transaction-dialog-close-button");
   });
 
-  it("The rewards claim transaction workflow can be completed", () => {
+  it("The unlocking transaction workflow can be completed", () => {
     UTILS.findAndClick("stake-button");
-    UTILS.findAndClick(
-      "validator-cosmosvaloper15urq2dtp9qce4fyc85m6upwm9xul3049e02707",
-    );
-    UTILS.findAndClick("claim-rewards-button");
+    UTILS.findAndClick("unlock-gold-button");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
 
     // Error with no validators selected:
     UTILS.shouldMatchText(
-      "claims-transaction-error",
-      "Please select at least one validator to withdraw rewards from.",
+      "amount-transaction-error",
+      "Please input an amount.",
     );
 
-    // Check both:
-    UTILS.findAndClick("validator-check-option-0");
-    UTILS.findAndClick("validator-check-option-1");
-
-    // Uncheck both:
-    UTILS.findAndClick("validator-check-option-0");
-    UTILS.findAndClick("validator-check-option-1");
-
-    UTILS.findAndClick("ledger-dialog-confirmation-button");
-
-    // Error should persist after checking and unchecking both options;
-    UTILS.shouldMatchText(
-      "claims-transaction-error",
-      "Please select at least one validator to withdraw rewards from.",
-    );
-
-    // Check both and proceed
-    UTILS.findAndClick("validator-check-option-0");
-    UTILS.findAndClick("validator-check-option-1");
+    UTILS.findAndClick("transaction-delegate-all-toggle");
 
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     cy.wait(5000);
-    UTILS.findAndClick("transaction-submit-button");
-    cy.wait(5000);
+
     UTILS.findAndClick("transaction-dialog-close-button");
   });
 
   it("The send transaction workflow can be completed", () => {
     UTILS.findAndClick("send-receive-button");
+
+    // Connect with ledger
+    UTILS.findAndClick("CELO-network-login");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
+    UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
 
     // Error with no validators selected:
@@ -106,7 +86,7 @@ describe("Test Ledger Transactions", () => {
     );
 
     // Error with very large value added:
-    UTILS.typeText("transaction-send-amount-input", "500000000000");
+    UTILS.typeText("transaction-send-amount-input", "5000000000000000000");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.shouldMatchText(
       "amount-send-transaction-error",
@@ -117,18 +97,11 @@ describe("Test Ledger Transactions", () => {
     UTILS.typeText("transaction-send-amount-input", "1");
     UTILS.typeText(
       "transaction-send-recipient-input",
-      "cosmos15v50ymp6n5dn73erkqtmq0u8adpl8d3ujv2e74",
+      "0x47b2dB6af05a55d42Ed0F3731735F9479ABF0673",
     );
 
-    // Set gas settings
-    UTILS.findAndClick("toggle-custom-gas-settings");
-    UTILS.typeText("custom-gas-price-input", "0.05");
-    UTILS.typeText("custom-gas-amount-input", "200000");
-
     UTILS.findAndClick("ledger-dialog-confirmation-button");
     UTILS.findAndClick("ledger-dialog-confirmation-button");
-    cy.wait(5000);
-    UTILS.findAndClick("transaction-submit-button");
     cy.wait(5000);
     UTILS.findAndClick("transaction-dialog-close-button");
   });

--- a/packages/cypress/src/integration/login.spec.ts
+++ b/packages/cypress/src/integration/login.spec.ts
@@ -1,7 +1,7 @@
 import { SCREEN_SIZES, UTILS } from "../support/cypress-utils";
 import { NETWORK_ADDRESS_DEFAULTS } from "@anthem/utils";
 
-const { COSMOS, OASIS, CELO } = NETWORK_ADDRESS_DEFAULTS;
+const { OASIS, CELO } = NETWORK_ADDRESS_DEFAULTS;
 
 /** ===========================================================================
  * Test logging in with an address
@@ -9,51 +9,7 @@ const { COSMOS, OASIS, CELO } = NETWORK_ADDRESS_DEFAULTS;
  */
 
 SCREEN_SIZES.forEach(({ size, type }) => {
-  describe("Anthem supports login with a Cosmo address", () => {
-    beforeEach(() => {
-      UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
-    });
-
-    afterEach(() => {
-      UTILS.logout(type);
-    });
-
-    it("After logging in with a Cosmos address, the user can switch to an Oasis address", () => {
-      if (!type.isDesktop()) {
-        return;
-      }
-
-      UTILS.checkForNetwork("cosmos");
-
-      // Enter an Oasis address
-      UTILS.typeText("dashboard-address-input", `${OASIS.account}{enter}`);
-      UTILS.checkForNetwork("oasis");
-    });
-
-    it("After logging in with an address balance details are visible for that address", () => {
-      if (type.isDesktop()) {
-        UTILS.checkForNetwork("cosmos");
-      }
-    });
-
-    it("The transaction history is rendered once an address is entered", () => {
-      cy.get(UTILS.find("transaction-list-item"))
-        .each(el => {
-          cy.wrap(el).get(UTILS.find("transaction-timestamp"));
-        })
-        .then(list => {
-          expect(list).length.to.be.greaterThan(0);
-        });
-    });
-
-    it("Cosmos address is persisted on page reload", () => {
-      cy.reload();
-      UTILS.shouldContainText("balance-total", "ATOMs");
-    });
-  });
-
-  describe("Anthem supports login with a Celo address", () => {
+  describe(`Anthem supports login with a Celo address, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
       UTILS.loginWithAddress(type, "celo");
@@ -61,18 +17,6 @@ SCREEN_SIZES.forEach(({ size, type }) => {
 
     afterEach(() => {
       UTILS.logout(type);
-    });
-
-    it("After logging in with a Celo address, the user can switch to an Cosmos address", () => {
-      if (!type.isDesktop()) {
-        return;
-      }
-
-      UTILS.checkForNetwork("celo");
-
-      // Enter an Oasis address
-      UTILS.typeText("dashboard-address-input", `${COSMOS.account}{enter}`);
-      UTILS.checkForNetwork("cosmos");
     });
 
     it("After logging in with an address balance details are visible for that address", () => {
@@ -97,7 +41,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
     });
   });
 
-  describe("Anthem supports login with an Oasis address", () => {
+  describe(`Anthem supports login with an Oasis address, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
       UTILS.loginWithAddress(type, "oasis");
@@ -123,33 +67,36 @@ SCREEN_SIZES.forEach(({ size, type }) => {
         });
     });
 
-    it("Cosmos address is persisted on page reload", () => {
+    it("Oasis address is persisted on page reload", () => {
       cy.reload();
-      UTILS.shouldContainText("balance-total", "ATOMs");
+      UTILS.shouldContainText("balance-total", "ROSEs");
     });
   });
 
-  describe("Transaction details can be viewed by searching transaction hashes", () => {
+  describe(`Transaction details can be viewed by searching transaction hashes, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
+      UTILS.loginWithAddress(type, "celo");
     });
 
     afterEach(() => {
       UTILS.logout(type);
     });
 
-    it("Cosmos transactions can be viewed by hash", () => {
+    it("Oasis transactions can be viewed by hash", () => {
       if (!type.isDesktop()) {
         return;
       }
 
-      // Enter a Cosmos transaction hash
-      UTILS.searchInAddressInput(COSMOS.tx_hash);
+      // Login with Oasis
+      UTILS.searchInAddressInput(OASIS.account);
 
-      UTILS.checkForNetwork("cosmos");
+      // Enter a Oasis transaction hash
+      UTILS.searchInAddressInput(OASIS.tx_hash);
+
+      UTILS.checkForNetwork("oasis");
       cy.contains("Transaction Detail");
-      cy.url().should("include", `cosmos/txs/${COSMOS.tx_hash.toLowerCase()}`);
+      cy.url().should("include", `oasis/txs/${OASIS.tx_hash.toLowerCase()}`);
     });
 
     it("Celo transactions can be viewed by hash", () => {
@@ -169,7 +116,7 @@ SCREEN_SIZES.forEach(({ size, type }) => {
     });
   });
 
-  describe("Celo Network display cUSD portfolio chart", () => {
+  describe(`Celo Network display cUSD portfolio chart, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
       UTILS.loginWithAddress(type, "celo");

--- a/packages/cypress/src/integration/navigation.spec.ts
+++ b/packages/cypress/src/integration/navigation.spec.ts
@@ -37,7 +37,7 @@ SCREEN_SIZES.forEach(({ type, size }) => {
   describe(`Test Dashboard Portfolio Routes, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
+      UTILS.loginWithAddress(type, "celo");
     });
 
     afterEach(() => {
@@ -49,17 +49,17 @@ SCREEN_SIZES.forEach(({ type, size }) => {
      */
     it("All navigation sub-routes in the Dashboard can be visited", () => {
       if (type.isDesktop()) {
-        cy.visit(`${APP_URL}/cosmos/total`);
+        cy.visit(`${APP_URL}/celo/total`);
         cy.url().should("contain", "/total");
 
-        cy.visit(`${APP_URL}/cosmos/available`);
+        cy.visit(`${APP_URL}/celo/available`);
         cy.url().should("contain", "/available");
 
-        cy.visit(`${APP_URL}/cosmos/rewards`);
+        cy.visit(`${APP_URL}/celo/rewards`);
         cy.url().should("contain", "/rewards");
 
-        cy.visit(`${APP_URL}/cosmos/staking`);
-        cy.url().should("contain", "/staking");
+        cy.visit(`${APP_URL}/celo/voting`);
+        cy.url().should("contain", "/voting");
       }
     });
 

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -19,7 +19,7 @@ SCREEN_SIZES.forEach(({ type, size }) => {
   describe(`Test Dashboard Portfolio Routes, viewport: ${size}`, () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
+      UTILS.loginWithAddress(type, "celo");
       visitSettingsPage(type);
     });
 

--- a/packages/cypress/src/integration/staking.spec.ts
+++ b/packages/cypress/src/integration/staking.spec.ts
@@ -1,7 +1,7 @@
 import { NETWORK_ADDRESS_DEFAULTS } from "@anthem/utils";
-import { SCREEN_SIZES, UTILS, APP_URL } from "../support/cypress-utils";
+import { APP_URL, SCREEN_SIZES, UTILS } from "../support/cypress-utils";
 
-const { COSMOS, CELO } = NETWORK_ADDRESS_DEFAULTS;
+const { CELO } = NETWORK_ADDRESS_DEFAULTS;
 
 /** ===========================================================================
  * Test the staking/ page
@@ -9,28 +9,6 @@ const { COSMOS, CELO } = NETWORK_ADDRESS_DEFAULTS;
  */
 
 SCREEN_SIZES.forEach(({ size, type }) => {
-  describe("Anthem supports staking for Cosmos networks", () => {
-    beforeEach(() => {
-      UTILS.setViewportSize(size);
-      UTILS.loginWithAddress(type, "cosmos");
-    });
-
-    afterEach(() => {
-      UTILS.logout(type);
-    });
-
-    it("After logging in with an address the staking page is accessible", () => {
-      cy.visit(`${APP_URL}/cosmos/delegate/${COSMOS.account}`);
-      cy.contains("Staking");
-      cy.contains("Withdraw Rewards");
-      cy.contains("Withdraw Commissions");
-
-      if (type.isDesktop()) {
-        UTILS.checkForNetwork("cosmos");
-      }
-    });
-  });
-
   describe("Anthem supports staking for Celo networks", () => {
     beforeEach(() => {
       UTILS.setViewportSize(size);

--- a/packages/server/src/resolvers/resolvers.ts
+++ b/packages/server/src/resolvers/resolvers.ts
@@ -95,7 +95,7 @@ const resolvers = {
             case "COSMOS":
             case "KAVA":
             case "TERRA":
-              stats = await COSMOS_SDK.fetchNetworkStats(network);
+              // stats = await COSMOS_SDK.fetchNetworkStats(network);
               break;
             case "OASIS":
               stats = await OASIS.fetchNetworkSummaryStats();

--- a/packages/utils/src/client/data/celoAccountBalances.json
+++ b/packages/utils/src/client/data/celoAccountBalances.json
@@ -4,16 +4,16 @@
     "height": "2556626",
     "availableGoldBalance": "1000000000000000016",
     "totalLockedGoldBalance": "50963195658106474251698",
-    "nonVotingLockedGoldBalance": "0",
+    "nonVotingLockedGoldBalance": "1",
     "votingLockedGoldBalance": "40963195658106474251698",
-    "pendingWithdrawalBalance": "0",
+    "pendingWithdrawalBalance": "1",
     "celoUSDValue": "5970399386662756655185",
     "delegations": [
       {
         "group": "0x47b2dB6af05a55d42Ed0F3731735F9479ABF0673",
         "totalVotes": "50963195658106474251698",
         "activeVotes": "50963195658106474251698",
-        "pendingVotes": "0"
+        "pendingVotes": "1"
       }
     ]
   }


### PR DESCRIPTION
- Removed unsupported networks from Network Summary Page & Ledger Signup Screen
- Returning null for all the cosmos related components
- Removed all Cosmos queries from the client
- Fixed all cypress tests to work with celo and oasis networks
- Disabled cosmos stats from server for "networkSummaries" query
- Updated celo account balance mock data
- A note to prevent users from sending tokens to the suggested addresses for exploring